### PR TITLE
Do merge in fresh worktree

### DIFF
--- a/bot.ml
+++ b/bot.ml
@@ -65,11 +65,7 @@ let git_delete repo remote_branch_name =
   git_push ~force:false repo "" remote_branch_name
 
 let git_make_ancestor ~base ref2 =
-  Printf.sprintf "git checkout -f %s" ref2
-  |&& Printf.sprintf
-        "git merge %s -m \"Bot merge $(git rev-parse %s) into $(git rev-parse \
-         %s)\" || { git merge --abort; false; }"
-        base base ref2
+  Printf.sprintf "../make_ancestor.sh %s %s" base ref2
 
 let extract_commit json =
   let open Yojson.Basic.Util in

--- a/make_ancestor.sh
+++ b/make_ancestor.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# usage: make_ancestor.sh base ref
+# PWD must be in the relevant git repo
+# merges base in ref if necessary
+
+set -ex
+
+if [ $# != 2 ]; then >&2 echo Bad argument count; fi
+
+base=$1
+ref=$2
+
+basecommit=$(git rev-parse "$base")
+refcommit=$(git rev-parse "$ref")
+
+wtree=$(mktemp -d)
+
+( git checkout --detach HEAD # if ref is already checked out add worktree errors
+  git worktree add "$wtree" "$ref"
+  pushd "$wtree"
+  if ! git merge "$base" -m "Bot merge $basecommit into $refcommit";
+  then
+      popd
+      git worktree remove --force "$wtree"
+      false
+  fi
+)
+git worktree remove --force "$wtree"


### PR DESCRIPTION
This should ensure fresh state better.

I split the merge command to a new sh file as doing concatenations in
ocaml is a pain and stops me from using shell linters etc.

This probably doesn't work as the call to make_ancestor.sh is using
PATH and I don't think it's in PATH, how to fix?