### PR TITLE
Post a comment when a job in allow failure mode fails.

### DIFF
--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -73,6 +73,7 @@ module PullRequest_Refs =
   query prRefs($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name:$repo) {
       pullRequest(number: $number) {
+        id
         baseRefName
         baseRefOid @bsDecoder(fn: "Yojson.Basic.to_string")
         headRefName

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -23,22 +23,22 @@ type pull_request_action =
   | PullRequestReopened
   | PullRequestSynchronized
 
-type pull_request_info =
-  {issue: issue_info; base: commit_info; head: commit_info; merged: bool}
+type 'a pull_request_info =
+  {issue: 'a; base: commit_info; head: commit_info; merged: bool}
 
 type project_card = {issue: issue option; column_id: int}
 
 type comment_info =
   { body: string
   ; author: string
-  ; pull_request: pull_request_info option
+  ; pull_request: issue_info pull_request_info option
   ; issue: issue_info }
 
 type msg =
   | NoOp of string
   | IssueClosed of issue_info
   | RemovedFromProject of project_card
-  | PullRequestUpdated of pull_request_action * pull_request_info
+  | PullRequestUpdated of pull_request_action * issue_info pull_request_info
   | BranchCreated of remote_ref_info
   | TagCreated of remote_ref_info
   | CommentCreated of comment_info


### PR DESCRIPTION
This is what was requested at the Coq Call today: if a job fails in allow failure mode, the bot checks if it was on a PR branch (`pr-<num>`) and if the commit corresponds to the current head of the branch. If that's the case, it posts a comment informing of the failure. In the special case where the failure was for the `library:ci-fiat_crypto_legacy`, then it pings @JasonGross.

The first commit is only a preliminary refactoring, the second commit is the one that adds the feature.