### PR TITLE
Moving the GitHub/GitLab queries and mutations to the relevant modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ the bot will create a merge commit and push this commit to GitLab so
 that what is tested is the result of merging the PR (similar to what
 Travis would test).  If the automatic merge fails, then the bot will
 push a failed status check on the PR, and set a "needs: rebase" label
-(it also removes the label when an updated version without conflicts
-is pushed).
+provided it already exists (it also removes the label when an updated
+version without conflicts is pushed).
 
 ![needs rebase label screenshot](screenshots/needs-rebase.png)
 

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -117,6 +117,42 @@ module Issue_Milestone =
   }
 |}]
 
+module GetLabelID =
+[%graphql
+{|
+  query getLabelId($owner: String!, $repo: String!, $name: String!) {
+    repository(owner: $owner, name: $repo) {
+      label(name: $name) {
+        id
+      }
+    }
+  }
+|}]
+
+module GetIssueID =
+[%graphql
+{|
+  query getIssueID($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        id
+      }
+    }
+  }
+|}]
+
+module GetPullRequestID =
+[%graphql
+{|
+  query getPullRequestID($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        id
+      }
+    }
+  }
+|}]
+
 (* Mutations *)
 
 module MoveCardToColumn =
@@ -145,6 +181,22 @@ module UpdateMilestone =
   mutation updateMilestone($issue: ID!, $milestone: ID!) {
     updateIssue(input: {id: $issue, milestoneId: $milestone}) {
       clientMutationId
+    }
+  }
+|}]
+
+module AddLabel =
+[%graphql
+{|
+  mutation addLabel($labelable: ID!, $label: ID!) {
+    addLabelsToLabelable(input: {labelableId: $labelable, labelIds: [$label]}) {
+      labelable {
+        labels(first: 10) {
+          nodes {
+            name
+          }
+        }
+      }
     }
   }
 |}]

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -200,3 +200,19 @@ module AddLabel =
     }
   }
 |}]
+
+module RemoveLabel =
+[%graphql
+{|
+  mutation removeLabel($labelable: ID!, $label: ID!) {
+    removeLabelsFromLabelable(input: {labelableId: $labelable, labelIds: [$label]}) {
+      labelable {
+        labels(first: 10) {
+          nodes {
+            name
+          }
+        }
+      }
+    }
+  }
+|}]

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -54,17 +54,25 @@ let reflect_pull_request_milestone ~token
 (* TODO: use GraphQL API *)
 
 let add_rebase_label (issue : GitHub_subscriptions.issue) ~token =
-  let body = Cohttp_lwt.Body.of_string "[ \"needs: rebase\" ]" in
-  let uri =
-    f "https://api.github.com/repos/%s/%s/issues/%d/labels" issue.owner
-      issue.repo issue.number
-    |> (fun url ->
-         Stdio.printf "URL: %s\n" url ;
-         url)
-    |> Uri.of_string
-  in
-  let github_header = [("Authorization", "bearer " ^ token)] in
-  send_request ~body ~uri github_header
+  GitHub_queries.get_pr_id ~owner:issue.owner ~repo:issue.repo
+    ~number:issue.number ~token
+  >>= function
+  | Error e ->
+      Lwt_io.printf "Error while adding rebase label: %s" e
+  | Ok pr_id -> (
+      GitHub_queries.get_label_id ~owner:issue.owner ~repo:issue.repo
+        ~name:"needs: rebase" ~token
+      >>= function
+      | Error e ->
+          Lwt_io.printf "Error while adding rebase label: %s" e
+      | Ok label_id -> (
+          AddLabel.make ~labelable:pr_id ~label:label_id ()
+          |> GitHub_queries.send_graphql_query ~token
+          >|= function
+          | Ok _ ->
+              ()
+          | Error err ->
+              print_endline (f "Error while adding rebase label: %s" err) ) )
 
 let remove_rebase_label (issue : GitHub_subscriptions.issue) ~token =
   let github_header = [("Authorization", "bearer " ^ token)] in

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -1,5 +1,6 @@
 open Base
 open GitHub_GraphQL
+open Cohttp_lwt_unix
 open Lwt
 open Utils
 
@@ -49,3 +50,92 @@ let reflect_pull_request_milestone ~token
               ~message:
                 "The milestone of this issue was changed to reflect the one of \
                  the pull request that closed it." )
+
+(* TODO: use GraphQL API *)
+
+let add_rebase_label (issue : GitHub_subscriptions.issue) ~token =
+  let body = Cohttp_lwt.Body.of_string "[ \"needs: rebase\" ]" in
+  let uri =
+    f "https://api.github.com/repos/%s/%s/issues/%d/labels" issue.owner
+      issue.repo issue.number
+    |> (fun url ->
+         Stdio.printf "URL: %s\n" url ;
+         url)
+    |> Uri.of_string
+  in
+  let github_header = [("Authorization", "bearer " ^ token)] in
+  send_request ~body ~uri github_header
+
+let remove_rebase_label (issue : GitHub_subscriptions.issue) ~token =
+  let github_header = [("Authorization", "bearer " ^ token)] in
+  let headers = headers github_header in
+  let uri =
+    f "https://api.github.com/repos/%s/%s/issues/%d/labels/needs%%3A rebase"
+      issue.owner issue.repo issue.number
+    |> (fun url ->
+         Stdio.printf "URL: %s\n" url ;
+         url)
+    |> Uri.of_string
+  in
+  Lwt_io.printf "Sending delete request.\n"
+  >>= fun () -> Client.delete ~headers uri >>= print_response
+
+let update_milestone new_milestone (issue : GitHub_subscriptions.issue) ~token =
+  let github_header = [("Authorization", "bearer " ^ token)] in
+  let headers = headers github_header in
+  let uri =
+    f "https://api.github.com/repos/%s/%s/issues/%d" issue.owner issue.repo
+      issue.number
+    |> (fun url ->
+         Stdio.printf "URL: %s\n" url ;
+         url)
+    |> Uri.of_string
+  in
+  let body =
+    "{\"milestone\": " ^ new_milestone ^ "}" |> Cohttp_lwt.Body.of_string
+  in
+  Lwt_io.printf "Sending patch request.\n"
+  >>= fun () -> Client.patch ~headers ~body uri >>= print_response
+
+let remove_milestone = update_milestone "null"
+
+let send_status_check ~repo_full_name ~commit ~state ~url ~context ~description
+    ~token =
+  Lwt_io.printf "Sending status check to %s (commit %s, state %s)\n"
+    repo_full_name commit state
+  >>= fun () ->
+  let body =
+    "{\"state\": \"" ^ state ^ "\",\"target_url\":\"" ^ url
+    ^ "\", \"description\": \"" ^ description ^ "\", \"context\": \"" ^ context
+    ^ "\"}"
+    |> (fun body ->
+         Stdio.printf "Body:\n %s\n" body ;
+         body)
+    |> Cohttp_lwt.Body.of_string
+  in
+  let uri =
+    "https://api.github.com/repos/" ^ repo_full_name ^ "/statuses/" ^ commit
+    |> Uri.of_string
+  in
+  let github_header = [("Authorization", "bearer " ^ token)] in
+  send_request ~body ~uri github_header
+
+let add_pr_to_column pr_id column_id ~token =
+  let body =
+    "{\"content_id\":" ^ Int.to_string pr_id
+    ^ ", \"content_type\": \"PullRequest\"}"
+    |> (fun body ->
+         Stdio.printf "Body:\n%s\n" body ;
+         body)
+    |> Cohttp_lwt.Body.of_string
+  in
+  let uri =
+    "https://api.github.com/projects/columns/" ^ Int.to_string column_id
+    ^ "/cards"
+    |> (fun url ->
+         Stdio.printf "URL: %s\n" url ;
+         url)
+    |> Uri.of_string
+  in
+  let github_header = [("Authorization", "bearer " ^ token)] in
+  send_request ~body ~uri (project_api_preview_header @ github_header)

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -322,3 +322,33 @@ let get_issue_closer_info ~token
   >|= Result.map_error ~f:(fun err ->
           f "Query issue_milestone failed with %s" err)
   >|= Result.bind ~f:(issue_closer_info_of_resp ~owner ~repo ~number)
+
+(* TODO: use GraphQL API *)
+
+let get_status_check ~repo_full_name ~commit ~context =
+  generic_get
+    (Printf.sprintf "repos/%s/commits/%s/statuses" repo_full_name commit)
+    ~default:false (fun json ->
+      let open Yojson.Basic.Util in
+      json |> to_list
+      |> List.exists ~f:(fun json ->
+             json |> member "context" |> to_string |> String.equal context))
+
+let get_cards_in_column column_id =
+  generic_get
+    ("projects/columns/" ^ Int.to_string column_id ^ "/cards")
+    ~header_list:project_api_preview_header ~default:[]
+    (fun json ->
+      let open Yojson.Basic.Util in
+      json |> to_list
+      |> List.filter_map ~f:(fun json ->
+             let card_id = json |> member "id" |> to_int in
+             let content_url =
+               json |> member "content_url" |> to_string_option
+               |> Option.value ~default:""
+             in
+             let regexp = "https://api.github.com/repos/.*/\\([0-9]*\\)" in
+             if string_match ~regexp content_url then
+               let pr_number = Str.matched_group 1 content_url in
+               Some (pr_number, card_id)
+             else None))

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -323,6 +323,57 @@ let get_issue_closer_info ~token
           f "Query issue_milestone failed with %s" err)
   >|= Result.bind ~f:(issue_closer_info_of_resp ~owner ~repo ~number)
 
+let label_id_of_resp ~owner ~repo ~name resp =
+  match resp#repository with
+  | None ->
+      Error (f "Unknown repository %s/%s." owner repo)
+  | Some repository -> (
+    match repository#label with
+    | None ->
+        Error (f "Label %s does not exist." name)
+    | Some label ->
+        Ok label#id )
+
+let get_label_id ~owner ~repo ~name ~token =
+  GetLabelID.make ~owner ~repo ~name ()
+  |> send_graphql_query ~token
+  >|= Result.map_error ~f:(fun err -> f "Query get_label failed with %s" err)
+  >|= Result.bind ~f:(label_id_of_resp ~owner ~repo ~name)
+
+let issue_id_of_resp ~owner ~repo ~number resp =
+  match resp#repository with
+  | None ->
+      Error (f "Unknown repository %s/%s." owner repo)
+  | Some repository -> (
+    match repository#issue with
+    | None ->
+        Error (f "Issue %d does not exist." number)
+    | Some issue ->
+        Ok issue#id )
+
+let get_issue_id ~owner ~repo ~number ~token =
+  GetIssueID.make ~owner ~repo ~number ()
+  |> send_graphql_query ~token
+  >|= Result.map_error ~f:(fun err -> f "Query get_issue_id failed with %s" err)
+  >|= Result.bind ~f:(issue_id_of_resp ~owner ~repo ~number)
+
+let pr_id_of_resp ~owner ~repo ~number resp =
+  match resp#repository with
+  | None ->
+      Error (f "Unknown repository %s/%s." owner repo)
+  | Some repository -> (
+    match repository#pullRequest with
+    | None ->
+        Error (f "Issue %d does not exist." number)
+    | Some pr ->
+        Ok pr#id )
+
+let get_pr_id ~owner ~repo ~number ~token =
+  GetPullRequestID.make ~owner ~repo ~number ()
+  |> send_graphql_query ~token
+  >|= Result.map_error ~f:(fun err -> f "Query get_pr_id failed with %s" err)
+  >|= Result.bind ~f:(pr_id_of_resp ~owner ~repo ~number)
+
 (* TODO: use GraphQL API *)
 
 let get_status_check ~repo_full_name ~commit ~context =

--- a/bot-components/GitLab_mutations.ml
+++ b/bot-components/GitLab_mutations.ml
@@ -1,0 +1,13 @@
+open Utils
+
+let retry_job ~project_id ~build_id ~token =
+  let uri =
+    "https://gitlab.com/api/v4/projects/" ^ Int.to_string project_id ^ "/jobs/"
+    ^ Int.to_string build_id ^ "/retry"
+    |> (fun url ->
+         Stdio.printf "URL: %s\n" url ;
+         url)
+    |> Uri.of_string
+  in
+  let gitlab_header = [("Private-Token", token)] in
+  send_request ~body:Cohttp_lwt.Body.empty ~uri gitlab_header

--- a/bot-components/GitLab_queries.ml
+++ b/bot-components/GitLab_queries.ml
@@ -1,0 +1,14 @@
+open Cohttp_lwt_unix
+open Lwt
+open Utils
+
+let get_build_trace ~project_id ~build_id ~token =
+  let uri =
+    "https://gitlab.com/api/v4/projects/" ^ Int.to_string project_id ^ "/jobs/"
+    ^ Int.to_string build_id ^ "/trace"
+    |> Uri.of_string
+  in
+  let gitlab_header = [("Private-Token", token)] in
+  let headers = headers gitlab_header in
+  Client.get ~headers uri
+  >>= fun (_response, body) -> Cohttp_lwt.Body.to_string body

--- a/bot.ml
+++ b/bot.ml
@@ -114,7 +114,7 @@ let pull_request_updated
     if pr_info.issue.labels |> List.exists ~f:(String.equal "needs: rebase")
     then
       (fun () ->
-        GitHub_mutations.remove_rebase_label pr_info.issue.issue
+        GitHub_mutations.remove_rebase_label pr_info.issue
           ~token:github_access_token)
       |> Lwt.async ;
     (* Force push *)
@@ -122,8 +122,7 @@ let pull_request_updated
   else (
     (* Remove rebase label *)
     (fun () ->
-      GitHub_mutations.add_rebase_label pr_info.issue.issue
-        ~token:github_access_token)
+      GitHub_mutations.add_rebase_label pr_info.issue ~token:github_access_token)
     |> Lwt.async ;
     (* Add fail status check *)
     GitHub_mutations.send_status_check


### PR DESCRIPTION
After moving the GitHub/GitLab queries and mutations to the relevant modules, we then rewrite `add_rebase_label` to use GitHub's GraphQL API.