### PR TITLE
Integrate with run-coq-bug-minimizer GitHub action.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM alpine:3.10 AS app
 WORKDIR /app
 
 COPY --from=builder /src/opam-install/bin/bot bot.exe
-COPY --from=builder /src/make_ancestor.sh ./
+COPY --from=builder /src/make_ancestor.sh /src/coq_bug_minimizer.sh ./
 
 RUN apk update \
   && apk add bash git \

--- a/bot.ml
+++ b/bot.ml
@@ -815,7 +815,11 @@ let callback _conn req body =
                          "git push https://%s:%s@github.com/%s.git --delete \
                           '%s'"
                          bot_name github_access_token repo_name branch_name)
-                  >>= fun _ -> Lwt.return () ))
+                  >>= function
+                  | Ok () ->
+                      Lwt.return ()
+                  | Error f ->
+                      Lwt_io.printf "Error: %s" f ))
             |> Lwt.async ;
             Server.respond_string ~status:`OK ~body:"" ()
         | _ ->

--- a/coq_bug_minimizer.sh
+++ b/coq_bug_minimizer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# usage: coq_bug_minimizer.sh 'script' comment_thread_id comment_author github_token bot_name bot_domain
+
+set -ex
+
+if [ $# != 6 ]; then >&6 echo Bad argument count; fi
+
+script=$1
+comment_thread_id=$2
+comment_author=$3
+token=$4
+bot_name=$5
+bot_domain=$6
+branch_id=$(($(od -A n -t uI -N 5 /dev/urandom | tr -d ' ')))
+repo_name="JasonGross/run-coq-bug-minimizer"
+branch_name="run-coq-bug-minimizer-$branch_id"
+
+wtree=$(mktemp -d)
+
+git fetch "https://github.com/$repo_name.git" "refs/heads/master:$branch_name"
+git worktree add "$wtree" "$branch_name"
+pushd "$wtree"
+
+printf "%s %s %s %s" "$comment_thread_id" "$comment_author" "$repo_name" "$branch_name" > coqbot-request-stamp
+printf "%s\n" "$script" > coqbot.sh
+sed -i 's/\r$//g' coqbot.sh
+sed -i "s/COQBOT_URL='.*'/COQBOT_URL='https:\/\/$bot_domain\/coq-bug-minimizer'/" coqbot-config.sh
+git add .
+git commit -m "Added user script in coqbot.sh"
+git push --set-upstream "https://$bot_name:$token@github.com/$repo_name.git" "$branch_name"
+
+popd
+git worktree remove "$wtree"

--- a/coq_bug_minimizer.sh
+++ b/coq_bug_minimizer.sh
@@ -25,7 +25,7 @@ pushd "$wtree"
 printf "%s %s %s %s" "$comment_thread_id" "$comment_author" "$repo_name" "$branch_name" > coqbot-request-stamp
 printf "%s\n" "$script" > coqbot.sh
 sed -i 's/\r$//g' coqbot.sh
-sed -i "s/COQBOT_URL='.*'/COQBOT_URL='https:\/\/$bot_domain\/coq-bug-minimizer'/" coqbot-config.sh
+echo "https://$bot_domain/coq-bug-minimizer" > coqbot.url
 git add .
 git commit -m "Added user script in coqbot.sh"
 git push --set-upstream "https://$bot_name:$token@github.com/$repo_name.git" "$branch_name"


### PR DESCRIPTION
This patch allows coqbot to reply to '@coqbot: minimize' messages with the results of @JasonGross' [Coq bug minimizer](https://github.com/JasonGross/run-coq-bug-minimizer).

Here is an example:
![minimizer](https://user-images.githubusercontent.com/54635632/87680230-70786800-c77d-11ea-8d56-69ea72b48783.png)

Before merging this, we'd need to change the repository in the `coq_bug_minimizer` script to the original one (it uses a fork currently).

I also did some preliminary work to listen to check run events, so that coqbot could reply back once the check run starts, with a link to the running check.