### PR TITLE
Bot merge

### DIFF
--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -193,7 +193,7 @@ module UpdateMilestone =
 module MergePullRequest =
 [%graphql
 {|
-  mutation mergePullRequest($pr_id: ID!, $commit_headline: String!, $commit_body: String!, $merge_method: PullRequestMergeMethod) {
+  mutation mergePullRequest($pr_id: ID!, $commit_headline: String, $commit_body: String, $merge_method: PullRequestMergeMethod) {
     mergePullRequest(input: {pullRequestId: $pr_id, commitHeadline: $commit_headline, commitBody: $commit_body, mergeMethod: $merge_method}) {
       pullRequest {
         merged

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -124,7 +124,7 @@ module Issue_Milestone =
   }
 |}]
 
-module MergePullRequestInfo =
+module PullRequestReviewsInfo =
 [%graphql
 {|
   query mergePullRequestInfo($owner: String!, $repo: String!, $number: Int!) {

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -158,6 +158,20 @@ module PullRequestReviewsInfo =
   }
 |}]
 
+module FileContent =
+[%graphql
+{|
+  query fileContent($owner: String!, $repo: String!, $file: String!) {
+    repository(owner: $owner, name: $repo) {
+      file:object(expression: $file) {
+        ... on Blob {
+          text
+        }
+      }
+    }
+  }
+|}]
+
 (* Mutations *)
 
 module MoveCardToColumn =

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -130,22 +130,6 @@ module MergePullRequestInfo =
   query mergePullRequestInfo($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $number) {
-        assignees(first: 10) {
-          nodes {
-            login
-          }
-        }
-        author {
-          login
-        }
-        labels(first: 20) {
-          nodes {
-            name
-          }
-        }
-        milestone {
-          id
-        }
         reviewDecision
         reviews(first: 100) {
           nodes {

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -146,6 +146,7 @@ module MergePullRequestInfo =
         milestone {
           id
         }
+        reviewDecision
         reviews(first: 100) {
           nodes {
             author {

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -139,12 +139,18 @@ module MergePullRequestInfo =
           }
         }
         reviewDecision
-        reviews(last: 100) {
+        commentReviews: reviews(states: COMMENTED, last: 100) {
           nodes {
             author {
               login
             }
-            state
+          }
+        }
+        approvedReviews: reviews(states: APPROVED, last: 100) {
+          nodes {
+            author {
+              login
+            }
           }
         }
       }

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -124,6 +124,41 @@ module Issue_Milestone =
   }
 |}]
 
+module MergePullRequestInfo =
+[%graphql
+{|
+  query mergePullRequestInfo($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        assignees(first: 10) {
+          nodes {
+            login
+          }
+        }
+        author {
+          login
+        }
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+        milestone {
+          id
+        }
+        reviews(first: 100) {
+          nodes {
+            author {
+              login
+            }
+            state
+          }
+        }
+      }
+    }
+  }
+|}]
+
 (* Mutations *)
 
 module MoveCardToColumn =
@@ -152,6 +187,21 @@ module UpdateMilestone =
   mutation updateMilestone($issue: ID!, $milestone: ID!) {
     updateIssue(input: {id: $issue, milestoneId: $milestone}) {
       clientMutationId
+    }
+  }
+|}]
+
+module MergePullRequest =
+[%graphql
+{|
+  mutation mergePullRequest($pr_id: ID!) {
+    mergePullRequest(input: {pullRequestId: $pr_id}) {
+      pullRequest {
+        merged
+        mergedAt
+        state
+        url
+      }
     }
   }
 |}]

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -194,8 +194,8 @@ module UpdateMilestone =
 module MergePullRequest =
 [%graphql
 {|
-  mutation mergePullRequest($pr_id: ID!) {
-    mergePullRequest(input: {pullRequestId: $pr_id}) {
+  mutation mergePullRequest($pr_id: ID!, $commitHeadline: String!, $commitBody: String!, $mergeMethod: PullRequestMergeMethod) {
+    mergePullRequest(input: {pullRequestId: $pr_id, commitHeadline: $commitHeadline, commitBody: $commitBody, mergeMethod: $mergeMethod}) {
       pullRequest {
         merged
         mergedAt

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -130,8 +130,16 @@ module MergePullRequestInfo =
   query mergePullRequestInfo($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $number) {
+        baseRef {
+          name
+        }
+        files(first: 100) {
+          nodes {
+            path
+          }
+        }
         reviewDecision
-        reviews(first: 100) {
+        reviews(last: 100) {
           nodes {
             author {
               login

--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -193,8 +193,8 @@ module UpdateMilestone =
 module MergePullRequest =
 [%graphql
 {|
-  mutation mergePullRequest($pr_id: ID!, $commitHeadline: String!, $commitBody: String!, $mergeMethod: PullRequestMergeMethod) {
-    mergePullRequest(input: {pullRequestId: $pr_id, commitHeadline: $commitHeadline, commitBody: $commitBody, mergeMethod: $mergeMethod}) {
+  mutation mergePullRequest($pr_id: ID!, $commit_headline: String!, $commit_body: String!, $merge_method: PullRequestMergeMethod) {
+    mergePullRequest(input: {pullRequestId: $pr_id, commitHeadline: $commit_headline, commitBody: $commit_body, mergeMethod: $merge_method}) {
       pullRequest {
         merged
         mergedAt

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -32,6 +32,15 @@ let update_milestone ~bot_info ~issue ~milestone =
   | Error err ->
       Stdio.print_endline (f "Error while updating milestone: %s" err)
 
+let merge_pull_request ~bot_info ~pr_id =
+  MergePullRequest.make ~pr_id ()
+  |> GitHub_queries.send_graphql_query ~bot_info
+  >|= function
+  | Ok _ ->
+      ()
+  | Error err ->
+      Stdio.print_endline (f "Error while merging PR: %s" err)
+
 let reflect_pull_request_milestone ~bot_info
     (issue_closer_info : GitHub_queries.issue_closer_info) =
   match issue_closer_info.closer.milestone_id with

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -32,9 +32,9 @@ let update_milestone ~bot_info ~issue ~milestone =
   | Error err ->
       Stdio.print_endline (f "Error while updating milestone: %s" err)
 
-let merge_pull_request ?mergeMethod ~bot_info ~pr_id ~commitHeadline ~commitBody
-    =
-  MergePullRequest.make ~pr_id ~commitHeadline ~commitBody ?mergeMethod ()
+let merge_pull_request ?merge_method ~bot_info ~pr_id ~commit_headline
+    ~commit_body =
+  MergePullRequest.make ~pr_id ~commit_headline ~commit_body ?merge_method ()
   |> GitHub_queries.send_graphql_query ~bot_info
   >|= function
   | Ok _ ->

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -32,9 +32,9 @@ let update_milestone ~bot_info ~issue ~milestone =
   | Error err ->
       Stdio.print_endline (f "Error while updating milestone: %s" err)
 
-let merge_pull_request ?merge_method ~bot_info ~pr_id ~commit_headline
-    ~commit_body =
-  MergePullRequest.make ~pr_id ~commit_headline ~commit_body ?merge_method ()
+let merge_pull_request ?merge_method ?commit_headline ?commit_body ~bot_info
+    ~pr_id =
+  MergePullRequest.make ~pr_id ?commit_headline ?commit_body ?merge_method ()
   |> GitHub_queries.send_graphql_query ~bot_info
   >|= function
   | Ok _ ->

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -32,8 +32,9 @@ let update_milestone ~bot_info ~issue ~milestone =
   | Error err ->
       Stdio.print_endline (f "Error while updating milestone: %s" err)
 
-let merge_pull_request ~bot_info ~pr_id =
-  MergePullRequest.make ~pr_id ()
+let merge_pull_request ?mergeMethod ~bot_info ~pr_id ~commitHeadline ~commitBody
+    =
+  MergePullRequest.make ~pr_id ~commitHeadline ~commitBody ?mergeMethod ()
   |> GitHub_queries.send_graphql_query ~bot_info
   >|= function
   | Ok _ ->

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -314,24 +314,18 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                     []
                 | Some reviews ->
                     reviews |> Array.to_list |> List.filter_opt
-                    |> List.map ~f:(fun review ->
-                           match review#author with
-                           | None ->
-                               ""
-                           | Some (`Actor a) ->
-                               a#login) )
+                    |> List.filter_map ~f:(fun review ->
+                           review#author
+                           |> Option.map ~f:(fun (`Actor a) -> a#login)) )
             ; comment_reviews=
                 ( match comment_reviews#nodes with
                 | None ->
                     []
                 | Some reviews ->
                     reviews |> Array.to_list |> List.filter_opt
-                    |> List.map ~f:(fun review ->
-                           match review#author with
-                           | None ->
-                               ""
-                           | Some (`Actor a) ->
-                               a#login) )
+                    |> List.filter_map ~f:(fun review ->
+                           review#author
+                           |> Option.map ~f:(fun (`Actor a) -> a#login)) )
             ; review_decision=
                 ( match review_decision with
                 | `CHANGES_REQUESTED ->

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -292,13 +292,11 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
           Error "No approved reviews found."
       | _, _, _, None, _ ->
           Error "No comment reviews found."
-      | _, _, _, _, None ->
-          Error "No review decision found."
       | ( Some baseRef
         , Some files
         , Some approved_reviews
         , Some comment_reviews
-        , Some review_decision ) ->
+        , review_decision ) ->
           let approved_reviews =
             match approved_reviews#nodes with
             | None ->
@@ -335,12 +333,16 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                                   String.equal a b))) )
             ; review_decision=
                 ( match review_decision with
-                | `CHANGES_REQUESTED ->
-                    CHANGES_REQUESTED
-                | `APPROVED ->
-                    APPROVED
-                | `REVIEW_REQUIRED ->
-                    REVIEW_REQUIRED ) } ) )
+                | None ->
+                    NONE
+                | Some r -> (
+                  match r with
+                  | `CHANGES_REQUESTED ->
+                      CHANGES_REQUESTED
+                  | `APPROVED ->
+                      APPROVED
+                  | `REVIEW_REQUIRED ->
+                      REVIEW_REQUIRED ) ) } ) )
 
 let get_pull_request_reviews_refs ~bot_info ~owner ~repo ~number =
   PullRequestReviewsInfo.make ~owner ~repo ~number ()

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -342,7 +342,7 @@ let get_pull_request_reviews_refs ~bot_info ~owner ~repo ~number =
   PullRequestReviewsInfo.make ~owner ~repo ~number ()
   |> send_graphql_query ~bot_info
   >|= Result.map_error ~f:(fun err ->
-          f "Query merge_pull_request_info failed with %s" err)
+          f "Query pull_request_reviews_info failed with %s" err)
   >|= Result.bind ~f:(pull_request_reviews_info_of_resp ~owner ~repo ~number)
 
 let file_content_of_resp ~owner ~repo resp : (string option, string) Result.t =
@@ -361,8 +361,7 @@ let file_content_of_resp ~owner ~repo resp : (string option, string) Result.t =
 let get_file_content ~bot_info ~owner ~repo ~branch ~file_name =
   FileContent.make ~owner ~repo ~file:(branch ^ ":" ^ file_name) ()
   |> send_graphql_query ~bot_info
-  >|= Result.map_error ~f:(fun err ->
-          f "Query get_content_of_resp failed with %s" err)
+  >|= Result.map_error ~f:(fun err -> f "Query file_content failed with %s" err)
   >|= Result.bind ~f:(file_content_of_resp ~owner ~repo)
 
 type closer_info = {pull_request_id: string; milestone_id: string option}

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -342,7 +342,7 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                     REVIEW_REQUIRED ) } ) )
 
 let get_pull_request_reviews_refs ~bot_info ~owner ~repo ~number =
-  MergePullRequestInfo.make ~owner ~repo ~number ()
+  PullRequestReviewsInfo.make ~owner ~repo ~number ()
   |> send_graphql_query ~bot_info
   >|= Result.map_error ~f:(fun err ->
           f "Query merge_pull_request_info failed with %s" err)

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -281,22 +281,17 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
         ( pull_request#baseRef
         , pull_request#files
         , pull_request#approvedReviews
-        , pull_request#commentReviews
-        , pull_request#reviewDecision )
+        , pull_request#commentReviews )
       with
-      | None, _, _, _, _ ->
+      | None, _, _, _ ->
           Error "No base ref found."
-      | _, None, _, _, _ ->
+      | _, None, _, _ ->
           Error "No files found."
-      | _, _, None, _, _ ->
+      | _, _, None, _ ->
           Error "No approved reviews found."
-      | _, _, _, None, _ ->
+      | _, _, _, None ->
           Error "No comment reviews found."
-      | ( Some baseRef
-        , Some files
-        , Some approved_reviews
-        , Some comment_reviews
-        , review_decision ) ->
+      | Some baseRef, Some files, Some approved_reviews, Some comment_reviews ->
           let approved_reviews =
             match approved_reviews#nodes with
             | None ->
@@ -329,10 +324,10 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                            |> Option.map ~f:(fun (`Actor a) -> a#login))
                     |> List.filter ~f:(fun a ->
                            not
-                             (List.exists approved_reviews ~f:(fun b ->
-                                  String.equal a b))) )
+                             (List.exists approved_reviews ~f:(String.equal a)))
+                )
             ; review_decision=
-                ( match review_decision with
+                ( match pull_request#reviewDecision with
                 | None ->
                     NONE
                 | Some r -> (

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -20,13 +20,6 @@ type remote_ref_info = {repo_url: string; name: string}
 
 type commit_info = {branch: remote_ref_info; sha: string}
 
-type review_state =
-  | APPROVED
-  | CHANGES_REQUESTED
-  | COMMENTED
-  | DISMISSED
-  | PENDING
-
 type review_decision = CHANGES_REQUESTED | APPROVED | REVIEW_REQUIRED
 
 type pull_request_action =
@@ -45,7 +38,8 @@ type 'a pull_request_info =
 type pull_request_reviews_info =
   { baseRef: string
   ; files: string list
-  ; reviews: (string * review_state) list
+  ; approved_reviews: string list
+  ; comment_reviews: string list
   ; review_decision: review_decision }
 
 type project_card = {issue: issue option; column_id: int}

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -7,6 +7,7 @@ type issue = {owner: string; repo: string; number: int}
 
 type issue_info =
   { issue: issue
+  ; title: string
   ; id: string
   ; user: string
   ; labels: string list
@@ -76,6 +77,7 @@ let issue_info_of_json ?issue_json json =
       { owner= repo_json |> member "owner" |> member "login" |> to_string
       ; repo= repo_json |> member "name" |> to_string
       ; number= issue_json |> member "number" |> to_int }
+  ; title= issue_json |> member "title" |> to_string
   ; id= issue_json |> member "node_id" |> to_string
   ; user= issue_json |> member "user" |> member "login" |> to_string
   ; labels=

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -43,7 +43,10 @@ type 'a pull_request_info =
   ; last_commit_message: string option }
 
 type pull_request_reviews_info =
-  {reviews: (string * review_state) list; review_decision: review_decision}
+  { baseRef: string
+  ; files: string list
+  ; reviews: (string * review_state) list
+  ; review_decision: review_decision }
 
 type project_card = {issue: issue option; column_id: int}
 

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -18,6 +18,8 @@ type remote_ref_info = {repo_url: string; name: string}
 
 type commit_info = {branch: remote_ref_info; sha: string}
 
+type state = APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED | PENDING
+
 type pull_request_action =
   | PullRequestOpened
   | PullRequestClosed
@@ -30,6 +32,13 @@ type 'a pull_request_info =
   ; head: commit_info
   ; merged: bool
   ; last_commit_message: string option }
+
+type merge_pull_request_info =
+  { assignees: string list
+  ; author: string
+  ; milestone_id: string
+  ; reviews: (string * state) list
+  ; labels: string list }
 
 type project_card = {issue: issue option; column_id: int}
 

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -20,7 +20,7 @@ type remote_ref_info = {repo_url: string; name: string}
 
 type commit_info = {branch: remote_ref_info; sha: string}
 
-type review_decision = CHANGES_REQUESTED | APPROVED | REVIEW_REQUIRED
+type review_decision = CHANGES_REQUESTED | APPROVED | REVIEW_REQUIRED | NONE
 
 type pull_request_action =
   | PullRequestOpened

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -18,7 +18,14 @@ type remote_ref_info = {repo_url: string; name: string}
 
 type commit_info = {branch: remote_ref_info; sha: string}
 
-type state = APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED | PENDING
+type review_state =
+  | APPROVED
+  | CHANGES_REQUESTED
+  | COMMENTED
+  | DISMISSED
+  | PENDING
+
+type review_decision = CHANGES_REQUESTED | APPROVED | REVIEW_REQUIRED
 
 type pull_request_action =
   | PullRequestOpened
@@ -37,8 +44,9 @@ type merge_pull_request_info =
   { assignees: string list
   ; author: string
   ; milestone_id: string
-  ; reviews: (string * state) list
-  ; labels: string list }
+  ; reviews: (string * review_state) list
+  ; labels: string list
+  ; review_decision: review_decision }
 
 type project_card = {issue: issue option; column_id: int}
 

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -14,7 +14,6 @@ type issue_info =
   ; milestoned: bool
   ; pull_request: bool
   ; body: string option
-  ; milestone_id: string option
   ; assignees: string list }
 
 type remote_ref_info = {repo_url: string; name: string}
@@ -89,12 +88,6 @@ let issue_info_of_json ?issue_json json =
       issue_json |> member "html_url" |> to_string
       |> string_match ~regexp:"https://github.com/[^/]*/[^/]*/pull/[0-9]*"
   ; body= issue_json |> member "body" |> to_string_option
-  ; milestone_id=
-      ( match issue_json |> member "milestone" with
-      | `Null ->
-          None
-      | m ->
-          Some (m |> member "node_id" |> to_string) )
   ; assignees=
       issue_json |> member "assignees" |> to_list
       |> List.map ~f:(fun json -> json |> member "login" |> to_string) }

--- a/bot.ml
+++ b/bot.ml
@@ -892,7 +892,7 @@ let callback _conn req body =
                                   ~id:pr.id )
                             >>= fun () ->
                             GitHub_queries.get_team_membership ~bot_info
-                              ~org:"coq" ~team:"Pushers"
+                              ~org:"coq" ~team:"pushers"
                               ~user:comment_info.author
                             >>= function
                             | Ok _ ->

--- a/bot.ml
+++ b/bot.ml
@@ -899,7 +899,8 @@ let callback _conn req body =
                                 GitHub_mutations.merge_pull_request ~bot_info
                                   ~pr_id:pr.id
                                   ~commitHeadline:
-                                    (f "Merge PR #%d: " pr.issue.number)
+                                    (f "Merge PR #%d: %s" pr.issue.number
+                                       comment_info.issue.title)
                                   ~commitBody:(f "") ~mergeMethod:`MERGE
                             | Error _ ->
                                 GitHub_mutations.post_comment ~bot_info

--- a/bot.ml
+++ b/bot.ml
@@ -856,6 +856,16 @@ let callback _conn req body =
                                     authored it."
                                    comment_info.author)
                               ~id:pr.id
+                          else if
+                            not (String.equal reviews_info.baseRef "master")
+                          then
+                            GitHub_mutations.post_comment ~bot_info
+                              ~message:
+                                (f
+                                   "@%s: PR targets branch %s instead of \
+                                    master, abort merge."
+                                   comment_info.author reviews_info.baseRef)
+                              ~id:pr.id
                           else
                             GitHub_queries.get_team_membership ~bot_info
                               ~org:"coq" ~team:"Pushers"

--- a/bot.ml
+++ b/bot.ml
@@ -804,7 +804,9 @@ let callback _conn req body =
                 | Some l ->
                     GitHub_mutations.post_comment ~bot_info
                       ~message:
-                        (f "@%s: Needs label %s found, merge aborted."
+                        (f
+                           "@%s: This PR cannot be merged because there is \
+                            still a `%s` label."
                            comment_info.author l)
                       ~id:pr.id
                 | None -> (
@@ -815,13 +817,17 @@ let callback _conn req body =
                     then
                       GitHub_mutations.post_comment ~bot_info
                         ~message:
-                          (f "@%s: No kind label found, merge aborted."
+                          (f
+                             "@%s: This PR cannot be merged because there is \
+                              no `kind:` label."
                              comment_info.author)
                         ~id:pr.id
                     else if not comment_info.issue.milestoned then
                       GitHub_mutations.post_comment ~bot_info
                         ~message:
-                          (f "@%s: No milestone found, merge aborted."
+                          (f
+                             "@%s: This PR cannot be merged because no \
+                              milestone is set."
                              comment_info.author)
                         ~id:pr.id
                     else
@@ -830,8 +836,8 @@ let callback _conn req body =
                           GitHub_mutations.post_comment ~bot_info
                             ~message:
                               (f
-                                 "@%s: PR cannot be merged as it isn't \
-                                  approved yet."
+                                 "@%s: This PR cannot be merged because it \
+                                  hasn't been approved yet."
                                  comment_info.author)
                             ~id:pr.id
                       | APPROVED -> (
@@ -844,16 +850,16 @@ let callback _conn req body =
                             GitHub_mutations.post_comment ~bot_info
                               ~message:
                                 (f
-                                   "@%s: You can't merge the PR as you're not \
-                                    among the assignees."
+                                   "@%s: You can't merge the PR because you're \
+                                    not among the assignees."
                                    comment_info.author)
                               ~id:pr.id
                           else if String.equal comment_info.author pr.user then
                             GitHub_mutations.post_comment ~bot_info
                               ~message:
                                 (f
-                                   "@%s: You can't merge the PR since you \
-                                    authored it."
+                                   "@%s: You can't merge the PR because you \
+                                    are the author."
                                    comment_info.author)
                               ~id:pr.id
                           else if
@@ -862,8 +868,10 @@ let callback _conn req body =
                             GitHub_mutations.post_comment ~bot_info
                               ~message:
                                 (f
-                                   "@%s: PR targets branch %s instead of \
-                                    master, abort merge."
+                                   "@%s: This PR targets branch `%s` instead \
+                                    of `master`. Only release managers can \
+                                    merge in release branches. Merging with \
+                                    the bot is not supported."
                                    comment_info.author reviews_info.baseRef)
                               ~id:pr.id
                           else
@@ -922,8 +930,9 @@ let callback _conn req body =
                                 GitHub_mutations.post_comment ~bot_info
                                   ~message:
                                     (f
-                                       "@%s: You can't merge this PR as you're \
-                                        not a member of the Pushers team."
+                                       "@%s: You can't merge this PR because \
+                                        you're not a member of the \
+                                        `@coq/pushers` team."
                                        comment_info.author)
                                   ~id:pr.id ) ) )
               | Error e ->

--- a/bot.ml
+++ b/bot.ml
@@ -878,10 +878,14 @@ let callback _conn req body =
                                     (f "Merge PR #%d: %s" pr.issue.number
                                        comment_info.issue.title)
                                   ~commit_body:
-                                    (List.fold_left
-                                       reviews_info.approved_reviews
-                                       ~init:"Reviewed-by:\n" ~f:(fun s r ->
-                                         s ^ f "- %s\n" r))
+                                    ( List.fold_left
+                                        reviews_info.approved_reviews
+                                        ~init:"Reviewed-by:\n" ~f:(fun s r ->
+                                          s ^ f "- %s\n" r)
+                                    ^ List.fold_left
+                                        reviews_info.comment_reviews
+                                        ~init:"Ack-by:\n" ~f:(fun s r ->
+                                          s ^ f "- %s\n" r) )
                                   ~merge_method:`MERGE
                                 >>= fun () ->
                                 match

--- a/bot.ml
+++ b/bot.ml
@@ -732,7 +732,7 @@ let callback _conn req body =
             )
           else if
             string_match ~regexp:(f "@%s: [Rr]un CI now" bot_name) body
-            && Bool.equal comment_info.issue.pull_request true
+            && comment_info.issue.pull_request
           then
             match Map.find owner_team_map comment_info.issue.issue.owner with
             | Some team when signed ->
@@ -786,109 +786,99 @@ let callback _conn req body =
                   ()
           else if
             string_match ~regexp:(f "@%s: [Mm]erge now" bot_name) body
-            && Bool.equal comment_info.issue.pull_request true
+            && comment_info.issue.pull_request
             && String.equal comment_info.issue.issue.owner "coq"
             && String.equal comment_info.issue.issue.repo "coq"
-            (*&&
-              let pr =
-                (Option.value_exn ~message:"Attempting to merge an issue."
-                   comment_info.pull_request)
-                  .issue
-              in
-              String.equal pr.issue.owner "coq"
-              && String.equal pr.issue.repo "coq"*)
           then (
             (fun () ->
-              (*let pr =
-                  Option.value_exn ~message:"Attempting to merge an issue."
-                    comment_info.pull_request
-                in
-                GitHub_queries.get_merge_pull_request_refs ~bot_info
-                  ~owner:pr.issue.issue.owner ~repo:pr.issue.issue.repo
-                  ~number:pr.issue.issue.number*)
               let pr = comment_info.issue in
               GitHub_queries.get_merge_pull_request_refs ~bot_info
                 ~owner:pr.issue.owner ~repo:pr.issue.repo
                 ~number:pr.issue.number
               >>= function
               | Ok merge_info -> (
-                  if
-                    List.exists merge_info.labels ~f:(fun label ->
-                        string_match ~regexp:"needs:.*" label)
-                  then
+                match
+                  List.find merge_info.labels ~f:(fun label ->
+                      string_match ~regexp:"needs:.*" label)
+                with
+                | Some l ->
                     GitHub_mutations.post_comment ~bot_info
                       ~message:
-                        (f "@%s: Needs label found, merge aborted."
-                           comment_info.author)
+                        (f "@%s: Needs label %s found, merge aborted."
+                           comment_info.author l)
                       ~id:pr.id
-                  else if
-                    not
-                      (List.exists merge_info.labels ~f:(fun label ->
-                           string_match ~regexp:"kind:.*" label))
-                  then
-                    GitHub_mutations.post_comment ~bot_info
-                      ~message:
-                        (f "@%s: No kind label found, merge aborted."
-                           comment_info.author)
-                      ~id:pr.id
-                    (* merge_info already contains a valid milestone, no need to check if there's one *)
-                    (*else if
-                        List.exists merge_info.reviews ~f:(fun (_, state) ->
-                            match state with
-                            | GitHub_subscriptions.(CHANGES_REQUESTED | DISMISSED)
-                              ->
-                                true
-                            | _ ->
-                                false)
-                      then Lwt_io.print "Changes requested, abort merge\n"*)
-                  else if
-                    not
-                      (List.exists merge_info.reviews ~f:(fun (_, state) ->
-                           match state with
-                           | GitHub_subscriptions.APPROVED ->
-                               true
-                           | _ ->
-                               false))
-                  then
-                    GitHub_mutations.post_comment ~bot_info
-                      ~message:
-                        (f "@%s: PR cannot be merged as it isn't approved yet."
-                           comment_info.author)
-                      ~id:pr.id
-                  else if
-                    not
-                      (List.exists merge_info.assignees ~f:(fun login ->
-                           String.equal login comment_info.author))
-                    (* PR author must be among the assignees *)
-                  then
-                    GitHub_mutations.post_comment ~bot_info
-                      ~message:
-                        (f
-                           "@%s: You can't merge the PR as you're not among \
-                            the assignees."
-                           comment_info.author)
-                      ~id:pr.id
-                  else if String.equal comment_info.author pr.user then
-                    GitHub_mutations.post_comment ~bot_info
-                      ~message:
-                        (f "@%s: You can't merge the PR since you authored it."
-                           comment_info.author)
-                      ~id:pr.id
-                  else
-                    GitHub_queries.get_team_membership ~bot_info ~org:"coq"
-                      ~team:"Pushers" ~user:comment_info.author
-                    >>= function
-                    | Ok _ ->
-                        GitHub_mutations.merge_pull_request ~bot_info
-                          ~pr_id:pr.id
-                    | Error _ ->
-                        GitHub_mutations.post_comment ~bot_info
-                          ~message:
-                            (f
-                               "@%s: You can't merge this PR as you're not a \
-                                member of the Pushers team."
-                               comment_info.author)
-                          ~id:pr.id )
+                | None -> (
+                    if
+                      not
+                        (List.exists merge_info.labels ~f:(fun label ->
+                             string_match ~regexp:"kind:.*" label))
+                    then
+                      GitHub_mutations.post_comment ~bot_info
+                        ~message:
+                          (f "@%s: No kind label found, merge aborted."
+                             comment_info.author)
+                        ~id:pr.id
+                      (* merge_info already contains a valid milestone, no need to check if there's one *)
+                      (*else if
+                          List.exists merge_info.reviews ~f:(fun (_, state) ->
+                              match state with
+                              | GitHub_subscriptions.(CHANGES_REQUESTED | DISMISSED)
+                                ->
+                                  true
+                              | _ ->
+                                  false)
+                        then Lwt_io.print "Changes requested, abort merge\n"*)
+                    else if
+                      not
+                        (List.exists merge_info.reviews ~f:(fun (_, state) ->
+                             match state with
+                             | GitHub_subscriptions.APPROVED ->
+                                 true
+                             | _ ->
+                                 false))
+                    then
+                      GitHub_mutations.post_comment ~bot_info
+                        ~message:
+                          (f
+                             "@%s: PR cannot be merged as it isn't approved \
+                              yet."
+                             comment_info.author)
+                        ~id:pr.id
+                    else if
+                      not
+                        (List.exists merge_info.assignees ~f:(fun login ->
+                             String.equal login comment_info.author))
+                    then
+                      GitHub_mutations.post_comment ~bot_info
+                        ~message:
+                          (f
+                             "@%s: You can't merge the PR as you're not among \
+                              the assignees."
+                             comment_info.author)
+                        ~id:pr.id
+                    else if String.equal comment_info.author pr.user then
+                      GitHub_mutations.post_comment ~bot_info
+                        ~message:
+                          (f
+                             "@%s: You can't merge the PR since you authored \
+                              it."
+                             comment_info.author)
+                        ~id:pr.id
+                    else
+                      GitHub_queries.get_team_membership ~bot_info ~org:"coq"
+                        ~team:"Pushers" ~user:comment_info.author
+                      >>= function
+                      | Ok _ ->
+                          GitHub_mutations.merge_pull_request ~bot_info
+                            ~pr_id:pr.id
+                      | Error _ ->
+                          GitHub_mutations.post_comment ~bot_info
+                            ~message:
+                              (f
+                                 "@%s: You can't merge this PR as you're not a \
+                                  member of the Pushers team."
+                                 comment_info.author)
+                            ~id:pr.id ) )
               | Error e ->
                   Lwt_io.print e)
             |> Lwt.async ;

--- a/bot.ml
+++ b/bot.ml
@@ -851,12 +851,20 @@ let callback _conn req body =
                               ~id:pr.id
                           else
                             match reviews_info.review_decision with
-                            | NONE | REVIEW_REQUIRED | CHANGES_REQUESTED ->
+                            | NONE | REVIEW_REQUIRED ->
                                 GitHub_mutations.post_comment ~bot_info
                                   ~message:
                                     (f
                                        "@%s: This PR cannot be merged because \
                                         it hasn't been approved yet."
+                                       comment_info.author)
+                                  ~id:pr.id
+                            | CHANGES_REQUESTED ->
+                                GitHub_mutations.post_comment ~bot_info
+                                  ~message:
+                                    (f
+                                       "@%s: This PR cannot be merged because \
+                                        some changes are requested."
                                        comment_info.author)
                                   ~id:pr.id
                             | APPROVED -> (

--- a/bot.ml
+++ b/bot.ml
@@ -898,15 +898,15 @@ let callback _conn req body =
                             | Ok _ ->
                                 GitHub_mutations.merge_pull_request ~bot_info
                                   ~pr_id:pr.id
-                                  ~commitHeadline:
+                                  ~commit_headline:
                                     (f "Merge PR #%d: %s" pr.issue.number
                                        comment_info.issue.title)
-                                  ~commitBody:
+                                  ~commit_body:
                                     (List.fold_left
                                        reviews_info.approved_reviews
                                        ~init:"Reviewed-by:\n" ~f:(fun s r ->
                                          s ^ f "- %s\n" r))
-                                  ~mergeMethod:`MERGE
+                                  ~merge_method:`MERGE
                             | Error _ ->
                                 GitHub_mutations.post_comment ~bot_info
                                   ~message:

--- a/bot.ml
+++ b/bot.ml
@@ -916,7 +916,9 @@ let callback _conn req body =
                                        comment_info.author)
                                   ~id:pr.id ) ) )
               | Error e ->
-                  Lwt_io.print e)
+                  GitHub_mutations.post_comment ~bot_info
+                    ~message:(f "@%s: %s" comment_info.author e)
+                    ~id:pr.id)
             |> Lwt.async ;
             Server.respond_string ~status:`OK
               ~body:(f "Received a request to merge the PR.")

--- a/bot.ml
+++ b/bot.ml
@@ -882,10 +882,17 @@ let callback _conn req body =
                                         reviews_info.approved_reviews
                                         ~init:"Reviewed-by:\n" ~f:(fun s r ->
                                           s ^ f "- %s\n" r)
-                                    ^ List.fold_left
+                                    ^
+                                    if
+                                      not
+                                        (List.is_empty
+                                           reviews_info.comment_reviews)
+                                    then
+                                      List.fold_left
                                         reviews_info.comment_reviews
                                         ~init:"Ack-by:\n" ~f:(fun s r ->
-                                          s ^ f "- %s\n" r) )
+                                          s ^ f "- %s\n" r)
+                                    else "" )
                                   ~merge_method:`MERGE
                                 >>= fun () ->
                                 match

--- a/bot.ml
+++ b/bot.ml
@@ -871,6 +871,8 @@ let callback _conn req body =
                       | Ok _ ->
                           GitHub_mutations.merge_pull_request ~bot_info
                             ~pr_id:pr.id
+                            ~commitHeadline:(f "Merge PR #%d: " pr.issue.number)
+                            ~commitBody:(f "") ~mergeMethod:`MERGE
                       | Error _ ->
                           GitHub_mutations.post_comment ~bot_info
                             ~message:

--- a/bot.ml
+++ b/bot.ml
@@ -895,19 +895,12 @@ let callback _conn req body =
                                         ~commit_body:
                                           ( List.fold_left
                                               reviews_info.approved_reviews
-                                              ~init:"Reviewed-by:\n"
-                                              ~f:(fun s r -> s ^ f "- %s\n" r)
-                                          ^
-                                          if
-                                            not
-                                              (List.is_empty
-                                                 reviews_info.comment_reviews)
-                                          then
-                                            List.fold_left
+                                              ~init:"" ~f:(fun s r ->
+                                                s ^ f "Reviewed-by: %s\n" r)
+                                          ^ List.fold_left
                                               reviews_info.comment_reviews
-                                              ~init:"Ack-by:\n" ~f:(fun s r ->
-                                                s ^ f "- %s\n" r)
-                                          else "" )
+                                              ~init:"" ~f:(fun s r ->
+                                                s ^ f "Ack-by: %s\n" r) )
                                         ~merge_method:`MERGE
                                       >>= fun () ->
                                       match

--- a/bot.ml
+++ b/bot.ml
@@ -832,7 +832,7 @@ let callback _conn req body =
                         ~id:pr.id
                     else
                       match reviews_info.review_decision with
-                      | REVIEW_REQUIRED | CHANGES_REQUESTED ->
+                      | NONE | REVIEW_REQUIRED | CHANGES_REQUESTED ->
                           GitHub_mutations.post_comment ~bot_info
                             ~message:
                               (f
@@ -937,7 +937,10 @@ let callback _conn req body =
                                   ~id:pr.id ) ) )
               | Error e ->
                   GitHub_mutations.post_comment ~bot_info
-                    ~message:(f "@%s: %s" comment_info.author e)
+                    ~message:
+                      (f
+                         "@%s: Something unexpected happend: %s\n\
+                          cc @coq/coqbot-maintainers" comment_info.author e)
                     ~id:pr.id)
             |> Lwt.async ;
             Server.respond_string ~status:`OK

--- a/bot.ml
+++ b/bot.ml
@@ -901,7 +901,12 @@ let callback _conn req body =
                                   ~commitHeadline:
                                     (f "Merge PR #%d: %s" pr.issue.number
                                        comment_info.issue.title)
-                                  ~commitBody:(f "") ~mergeMethod:`MERGE
+                                  ~commitBody:
+                                    (List.fold_left
+                                       reviews_info.approved_reviews
+                                       ~init:"Reviewed-by:\n" ~f:(fun s r ->
+                                         s ^ f "- %s\n" r))
+                                  ~mergeMethod:`MERGE
                             | Error _ ->
                                 GitHub_mutations.post_comment ~bot_info
                                   ~message:


### PR DESCRIPTION
This patch brings the feature requested in #27 

What remains to be done:
- merge the PR if it targets the master branch
- check that CI passed
- skip the confirmation step by adding "Ignore CI failures" to the comment requesting to merge
- post a comment to remind the merger to take care of overlays (i.e. files in directory dev/ci/user-overlays)

For the moment, we also merge the PR if there's at least one approval, since we'd have to distinguish outdated 'request changes' feedbacks from recent ones.