### PR TITLE
Constant time equality

### DIFF
--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -227,9 +227,7 @@ let receive_github ~secret headers body =
           (Cstruct.of_string body)
         |> Hex.of_cstruct |> Hex.show |> f "sha1=%s"
       in
-      (* TODO: move to constant time equality function, such as https://github.com/mirage/eqaf,
-           as recommended by GitHub *)
-      if String.equal signature expected then return true
+      if Eqaf.equal signature expected then return true
       else fail "Webhook signed but with wrong signature."
   | None ->
       return false )

--- a/coq-bot.opam
+++ b/coq-bot.opam
@@ -19,6 +19,7 @@ depends: [
   "yojson" {>= "1.7.0"}
   "bot-components" {dev}
   "toml" {>= "5.0.0"}
+  "eqaf" {>= "0.7"}
   "odoc" {>= "1.4.0"}
 ]
 build: [

--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,8 @@ in stdenv.mkDerivation rec {
     yojson
     graphql_ppx
     toml
+    eqaf
+    odoc
     # Publishing
     heroku
   ];

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,7 @@
   (yojson (>= 1.7.0))
   (bot-components :dev)
   (toml (>= 5.0.0))
+  (eqaf (>= 0.7))
   (odoc (>= 1.4.0)))
 )
 (package


### PR DESCRIPTION
Let's compare cryptographic hashes in constant time to prevent timing attacks from happening.
These changes depend on #83