### PR TITLE
Escape script arguments to avoid issues with special characters.

### DIFF
--- a/make_ancestor.sh
+++ b/make_ancestor.sh
@@ -10,10 +10,10 @@ set -ex
 
 if [ $# != 4 ]; then >&2 echo Bad argument count; fi
 
-base=$1
-head=$2
-pr_title=$3
-prnum=$4
+base="$1"
+head="$2"
+pr_title="$3"
+prnum="$4"
 
 basecommit=$(git rev-parse "$base")
 headcommit=$(git rev-parse "$head")


### PR DESCRIPTION
The problem can appear especially in the `pr_title` which may contain, e.g. parentheses.

Fix #98.