### PR TITLE
bullet reasons why PR was not merged

### DIFF
--- a/src/actions.ml
+++ b/src/actions.ml
@@ -1688,29 +1688,30 @@ let rec merge_pull_request_action ~bot_info ?(t = 1.) comment_info =
   let reasons_for_not_merging =
     List.filter_opt
       [ ( if String.equal comment_info.author pr.user then
-          Some "you are the author"
+          Some "You are the author."
         else if
         List.exists
           ~f:(String.equal comment_info.author)
           comment_info.issue.assignees
       then None
-        else Some "you're not among the assignees" )
+        else Some "You are not among the assignees." )
       ; comment_info.issue.labels
         |> List.find ~f:(fun label -> string_match ~regexp:"needs:.*" label)
-        |> Option.map ~f:(fun l -> f "there is still a `%s` label" l)
+        |> Option.map ~f:(fun l -> f "There is still a `%s` label." l)
       ; ( if
           comment_info.issue.labels
           |> List.exists ~f:(fun label -> string_match ~regexp:"kind:.*" label)
         then None
-        else Some "there is no `kind:` label" )
+        else Some "There is no `kind:` label." )
       ; ( if comment_info.issue.milestoned then None
-        else Some "no milestone is set" ) ]
+        else Some "No milestone has been set." ) ]
   in
   ( match reasons_for_not_merging with
   | _ :: _ ->
-      let reasons = reasons_for_not_merging |> String.concat ~sep:" and " in
+      let bullet_reasons = reasons_for_not_merging |> List.map ~f:(fun x -> "- " ^ x) in
+      let reasons = bullet_reasons |> String.concat ~sep:"\n" in
       Lwt.return_error
-        (f "@%s: You can't merge the PR because %s." comment_info.author reasons)
+        (f "@%s: You cannot merge this PR because:\n%s." comment_info.author reasons)
   | [] -> (
       GitHub_queries.get_pull_request_reviews_refs ~bot_info
         ~owner:pr.issue.owner ~repo:pr.issue.repo ~number:pr.issue.number


### PR DESCRIPTION
We now list using bullets the reasons why a PR could not be merged.

I am unable to test that this actually works.

close #163