### PR TITLE
Changing expiration date 

### DIFF
--- a/bot-components/GitHub_app.ml
+++ b/bot-components/GitHub_app.ml
@@ -23,7 +23,7 @@ let make_jwt ~key ~app_id =
   let issuedAt = Unix.time () |> Int.of_float in
   let payload =
     f "{ \"iat\": %d, \"exp\": %d, \"iss\": %d }" issuedAt
-      (issuedAt + (60 * 10))
+      (issuedAt + (55 * 10))
       app_id
   in
   match (base64 header, base64 payload) with


### PR DESCRIPTION
from one hour to 55 minutes to make sure that it's not above one hour (max allowed by GitHub)

Fixes #204 