### PR TITLE
Strings that need to use double quotes are now enclosed in {| |} for readability

### DIFF
--- a/bot-components/GitHub_app.ml
+++ b/bot-components/GitHub_app.ml
@@ -19,10 +19,10 @@ let base64 = Base64.encode ~pad:false ~alphabet:Base64.uri_safe_alphabet
 
 (* The following functions are largely based on https://github.com/Schniz/reason-pr-labels *)
 let make_jwt ~key ~app_id =
-  let header = "{ \"alg\": \"RS256\" }" in
+  let header = {|{ "alg": "RS256" }|} in
   let issuedAt = Unix.time () |> Int.of_float in
   let payload =
-    f "{ \"iat\": %d, \"exp\": %d, \"iss\": %d }" issuedAt
+    f {|{ "iat": %d, "exp": %d, "iss": %d }|} issuedAt
       (issuedAt + (55 * 10))
       app_id
   in

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -202,7 +202,7 @@ let update_milestone ~bot_info new_milestone (issue : issue) =
     |> Uri.of_string
   in
   let body =
-    {|{"milestone": |} ^ new_milestone ^ "}" |> Cohttp_lwt.Body.of_string
+    f {|{"milestone": %s}|} new_milestone |> Cohttp_lwt.Body.of_string
   in
   Lwt_io.printf "Sending patch request.\n"
   >>= fun () -> Client.patch ~headers ~body uri >>= print_response
@@ -228,8 +228,7 @@ let send_status_check ~bot_info ~repo_full_name ~commit ~state ~url ~context
 
 let add_pr_to_column ~bot_info ~pr_id ~column_id =
   let body =
-    {|{"content_id":|} ^ Int.to_string pr_id
-    ^ {|, "content_type": "PullRequest"}|}
+    f {|{"content_id":%d, "content_type": "PullRequest"}|} pr_id
     |> (fun body ->
          Stdio.printf "Body:\n%s\n" body ;
          body )

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -202,7 +202,7 @@ let update_milestone ~bot_info new_milestone (issue : issue) =
     |> Uri.of_string
   in
   let body =
-    "{\"milestone\": " ^ new_milestone ^ "}" |> Cohttp_lwt.Body.of_string
+    {|{"milestone": |} ^ new_milestone ^ "}" |> Cohttp_lwt.Body.of_string
   in
   Lwt_io.printf "Sending patch request.\n"
   >>= fun () -> Client.patch ~headers ~body uri >>= print_response
@@ -215,9 +215,9 @@ let send_status_check ~bot_info ~repo_full_name ~commit ~state ~url ~context
     repo_full_name commit state
   >>= fun () ->
   let body =
-    "{\"state\": \"" ^ state ^ "\",\"target_url\":\"" ^ url
-    ^ "\", \"description\": \"" ^ description ^ "\", \"context\": \"" ^ context
-    ^ "\"}"
+    {|{"state": "|} ^ state ^ {|","target_url":"|} ^ url
+    ^ {|", "description": "|} ^ description ^ {|", "context": "|} ^ context
+    ^ {|"}|}
     |> Cohttp_lwt.Body.of_string
   in
   let uri =
@@ -228,8 +228,8 @@ let send_status_check ~bot_info ~repo_full_name ~commit ~state ~url ~context
 
 let add_pr_to_column ~bot_info ~pr_id ~column_id =
   let body =
-    "{\"content_id\":" ^ Int.to_string pr_id
-    ^ ", \"content_type\": \"PullRequest\"}"
+    {|{"content_id":|} ^ Int.to_string pr_id
+    ^ {|, "content_type": "PullRequest"}|}
     |> (fun body ->
          Stdio.printf "Body:\n%s\n" body ;
          body )

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -82,7 +82,7 @@ let comment_info_of_json ?(review_comment = false) json =
       | `Null (* body of review comments can be null *) ->
           ""
       | _ ->
-          raise (Yojson.Json_error "Unexpected type for field \"body\".") )
+          raise (Yojson.Json_error {|Unexpected type for field "body".|}) )
   ; author= comment_json |> member "user" |> member "login" |> to_string
   ; pull_request
   ; issue=

--- a/src/git_utils.ml
+++ b/src/git_utils.ml
@@ -9,7 +9,7 @@ let gitlab_repo ~bot_info ~gitlab_full_name =
   f "https://oauth2:%s@gitlab.com/%s.git" bot_info.gitlab_token gitlab_full_name
 
 let report_status command report code =
-  Error (f "Command \"%s\" %s %d\n" command report code)
+  Error (f {|Command "%s" %s %d\n|} command report code)
 
 let gitlab_ref ~bot_info ~(issue : issue) ~github_mapping ~gitlab_mapping =
   let gh_repo = issue.owner ^ "/" ^ issue.repo in
@@ -113,7 +113,7 @@ let git_make_ancestor ~pr_title ~pr_number ~base head =
 
 let git_test_modified ~base ~head pattern =
   let command =
-    f "git diff %s %s --name-only | grep \"%s\"" base head pattern
+    f {|git diff %s %s --name-only | grep "%s"|} base head pattern
   in
   Lwt_unix.system command
   >|= fun status ->
@@ -173,8 +173,8 @@ let git_run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo ~pr_number
 let init_git_bare_repository ~bot_info =
   Stdio.printf "Initializing repository...\n" ;
   "git init --bare"
-  |&& f "git config user.email \"%s\"" bot_info.email
-  |&& f "git config user.name \"%s\"" bot_info.name
+  |&& f {|git config user.email "%s"|} bot_info.email
+  |&& f {|git config user.name "%s"|} bot_info.name
   |> execute_cmd
   >|= function
   | Ok _ ->


### PR DESCRIPTION
This is a QoL change because I find it hard to read and debug strings that have `\"` instead of simply `"`