### PR TITLE
Add bench command for coqbot

### DIFF
--- a/bot-components/GitHub_GraphQL.ml
+++ b/bot-components/GitHub_GraphQL.ml
@@ -518,3 +518,25 @@ query getChecks($appId: Int!, $owner: String!, $repo:String!, $prNumber: Int!, $
   }
 }
 |}]
+
+module GetPipelineSummary =
+[%graphql
+{|
+query getChecks($appId: Int!, $owner: String!, $repo:String!, $head: String!) {
+  repository(name: $repo,owner:$owner) {
+    getPipelineSummaryCommit: object(expression: $head) {
+      ... on Commit {
+        checkSuites(first: 1,filterBy:{appId: $appId}) {
+          nodes {
+            getPipelineSummaryCheckRuns: checkRuns(first: 1, filterBy: {checkName:"GitLab CI pipeline (pull request)"}) {
+              nodes {
+                summary
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+|}]

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -777,8 +777,6 @@ let get_base_and_head_checks ~bot_info ~owner ~repo ~pr_number ~base ~head =
               | _ ->
                   Error "Got more than one checkSuite." ) )
 
-(* TODO: use GraphQL API *)
-
 let get_pipeline_summary ~bot_info ~owner ~repo ~head =
   let appId = bot_info.app_id in
   let open GitHub_GraphQL.GetPipelineSummary in
@@ -835,6 +833,8 @@ let get_pipeline_summary ~bot_info ~owner ~repo ~head =
                       Error "Got more than one checkRun." ) )
               | _ ->
                   Error "Got more than one checkSuite." ) )
+
+(* TODO: use GraphQL API *)
 
 let get_cards_in_column column_id =
   generic_get

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -779,6 +779,63 @@ let get_base_and_head_checks ~bot_info ~owner ~repo ~pr_number ~base ~head =
 
 (* TODO: use GraphQL API *)
 
+let get_pipeline_summary ~bot_info ~owner ~repo ~head =
+  let appId = bot_info.app_id in
+  let open GitHub_GraphQL.GetPipelineSummary in
+  makeVariables ~appId ~owner ~repo ~head ()
+  |> serializeVariables |> variablesToJson
+  |> GraphQL_query.send_graphql_query ~bot_info ~query
+       ~parse:(Fn.compose parse unsafe_fromJson)
+  >|= Result.bind ~f:(fun resp ->
+          resp.repository
+          |> Result.of_option ~error:(f "Unknown repository %s/%s." owner repo) )
+  >|= Result.bind ~f:(fun repository ->
+          match repository.getPipelineSummaryCommit with
+          | None ->
+              Error (f "Unknown head commit %s/%s@%s." owner repo head)
+          | Some (`UnspecifiedFragment _) ->
+              Error "Unspecified fragment."
+          | Some (`Commit head_obj) -> (
+              let extract_check_suites checkSuites =
+                checkSuites
+                |> Option.bind ~f:(fun checkSuites -> checkSuites.nodes)
+                |> Option.map ~f:Array.to_list
+                |> Option.map ~f:List.filter_opt
+              in
+              match extract_check_suites head_obj.checkSuites with
+              | None ->
+                  Error
+                    (f "No check suite %d for head commit %s/%s@%s." appId owner
+                       repo head )
+              | Some [headCheckSuite] -> (
+                match headCheckSuite.getPipelineSummaryCheckRuns with
+                | None ->
+                    Error
+                      (f
+                         "No GitLab CI pipeline summary for head commit \
+                          %s/%s@%s."
+                         owner repo head )
+                | Some checkRuns -> (
+                  match checkRuns.nodes |> Option.map ~f:Array.to_list with
+                  | None | Some [None] ->
+                      Error
+                        (f
+                           "No GitLab CI pipeline summary for head commit \
+                            %s/%s@%s."
+                           owner repo head )
+                  | Some [Some headCheckRun] ->
+                      Stdlib.Option.to_result
+                        ~none:
+                          (f
+                             "No GitLab CI pipeline summary for head commit \
+                              %s/%s@%s."
+                             owner repo head )
+                        headCheckRun.summary
+                  | Some _ ->
+                      Error "Got more than one checkRun." ) )
+              | _ ->
+                  Error "Got more than one checkSuite." ) )
+
 let get_cards_in_column column_id =
   generic_get
     ("projects/columns/" ^ Int.to_string column_id ^ "/cards")

--- a/bot-components/GitHub_queries.mli
+++ b/bot-components/GitHub_queries.mli
@@ -99,6 +99,13 @@ val get_base_and_head_checks :
   -> head:string
   -> (base_and_head_checks_info, string) result Lwt.t
 
+val get_pipeline_summary :
+     bot_info:Bot_info.t
+  -> owner:string
+  -> repo:string
+  -> head:string
+  -> (string, string) result Lwt.t
+
 val get_cards_in_column :
   int -> bot_info:Bot_info.t -> ((string * int) list, string) result Lwt.t
 

--- a/bot-components/GitLab_mutations.ml
+++ b/bot-components/GitLab_mutations.ml
@@ -12,3 +12,12 @@ let retry_job ~bot_info ~project_id ~build_id =
     ~url_part:
       ( "projects/" ^ Int.to_string project_id ^ "/jobs/"
       ^ Int.to_string build_id )
+
+let play_job ~bot_info ~project_id ~build_id =
+  let uri =
+    Uri.of_string
+    @@ Printf.sprintf "https://gitlab.com/api/v4/projects/%d/jobs/%d/play"
+         project_id build_id
+  in
+  let gitlab_header = [("Private-Token", bot_info.gitlab_token)] in
+  Utils.send_request ~body:Cohttp_lwt.Body.empty ~uri gitlab_header ~bot_info

--- a/bot-components/GitLab_mutations.mli
+++ b/bot-components/GitLab_mutations.mli
@@ -2,3 +2,6 @@ val retry_job :
   bot_info:Bot_info.t -> project_id:int -> build_id:int -> unit Lwt.t
 
 val generic_retry : bot_info:Bot_info.t -> url_part:string -> unit Lwt.t
+
+val play_job :
+  bot_info:Bot_info.t -> project_id:int -> build_id:int -> unit Lwt.t

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -2499,9 +2499,10 @@ let coq_check_stale_pr ~bot_info ~owner ~repo ~after ~throttle =
 let run_bench ~bot_info comment_info =
   (* Do we want to use this more often? *)
   let open Lwt.Syntax in
-  let owner = comment_info.issue.issue.owner in
-  let repo = comment_info.issue.issue.repo in
-  let pr_number = comment_info.issue.number in
+  let pr = comment_info.issue in
+  let owner = pr.issue.owner in
+  let repo = pr.issue.repo in
+  let pr_number = pr.number in
   (* We need the GitLab build_id and project_id. Currently there is no good way
      to query this data so we have to jump through some somewhat useless hoops in
      order to get our hands on this information. TODO: do this more directly.*)
@@ -2552,30 +2553,56 @@ let run_bench ~bot_info comment_info =
                       running bench job."
                      owner repo pr_number ) ) )
   in
-  match gitlab_check_summary with
-  | Error err ->
-      Lwt_io.printlf "Error: %s\n" err
-  | Ok summary -> (
-    try
-      let build_id =
-        let regexp =
-          f {|.*%s\([0-9]*\)|}
-            (Str.quote "[bench](https://gitlab.com/coq/coq/-/jobs/")
+  (* Parsing the summary into (build_id, project_id) *)
+  let* process_summary =
+    match gitlab_check_summary with
+    | Error err ->
+        Lwt.return_error err
+    | Ok summary -> (
+      try
+        let build_id =
+          let regexp =
+            f {|.*%s\([0-9]*\)|}
+              (Str.quote "[bench](https://gitlab.com/coq/coq/-/jobs/")
+          in
+          ( if Helpers.string_match ~regexp summary then
+            Str.matched_group 1 summary
+          else raise @@ Stdlib.Failure "Could not find GitLab bench job ID" )
+          |> Stdlib.int_of_string
         in
-        ( if Helpers.string_match ~regexp summary then
-          Str.matched_group 1 summary
-        else raise @@ Stdlib.Failure "Could not find GitLab bench job ID" )
-        |> Stdlib.int_of_string
-      in
-      let project_id =
-        let regexp = {|.*GitLab Project ID: \([0-9]*\)|} in
-        ( if Helpers.string_match ~regexp summary then
-          Str.matched_group 1 summary
-        else raise @@ Stdlib.Failure "Could not find GitLab Project ID" )
-        |> Int.of_string
-      in
+        let project_id =
+          let regexp = {|.*GitLab Project ID: \([0-9]*\)|} in
+          ( if Helpers.string_match ~regexp summary then
+            Str.matched_group 1 summary
+          else raise @@ Stdlib.Failure "Could not find GitLab Project ID" )
+          |> Int.of_string
+        in
+        Lwt.return_ok (build_id, project_id)
+      with Stdlib.Failure s ->
+        Lwt.return_error
+          (f
+             "Error while regexing summary for %s/%s#%d for running bench job: \
+              %s"
+             owner repo pr_number s ) )
+  in
+  let* allowed_to_bench =
+    GitHub_queries.get_team_membership ~bot_info ~org:"coq" ~team:"pushers"
+      ~user:comment_info.author
+  in
+  match (allowed_to_bench, process_summary) with
+  | Ok true, Ok (build_id, project_id) ->
+      (* Permission to bench has been granted *)
       GitLab_mutations.play_job ~bot_info ~project_id ~build_id
-    with Stdlib.Failure s ->
-      Lwt_io.printlf
-        "Error while regexing summary for %s/%s#%d for running bench job: %s"
-        owner repo pr_number s )
+  | Error err, _ | _, Error err ->
+      GitHub_mutations.post_comment ~bot_info ~message:err ~id:pr.id
+      >>= GitHub_mutations.report_on_posting_comment
+  | Ok false, _ ->
+      (* User not found in the team *)
+      let err =
+        f
+          "@%s: You can't request a bench because you're not a member of the \
+           `@coq/pushers` team."
+          comment_info.author
+      in
+      GitHub_mutations.post_comment ~bot_info ~message:err ~id:pr.id
+      >>= GitHub_mutations.report_on_posting_comment

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -2553,7 +2553,7 @@ let run_bench ~bot_info comment_info =
              owner repo pr_number s ) )
   in
   let* allowed_to_bench =
-    GitHub_queries.get_team_membership ~bot_info ~org:"coq" ~team:"pushers"
+    GitHub_queries.get_team_membership ~bot_info ~org:"coq" ~team:"contributors"
       ~user:comment_info.author
   in
   match (allowed_to_bench, process_summary) with
@@ -2568,7 +2568,7 @@ let run_bench ~bot_info comment_info =
       let err =
         f
           "@%s: You can't request a bench because you're not a member of the \
-           `@coq/pushers` team."
+           `@coq/contributors` team."
           comment_info.author
       in
       GitHub_mutations.post_comment ~bot_info ~message:err ~id:pr.id

--- a/src/actions.mli
+++ b/src/actions.mli
@@ -32,6 +32,8 @@ val coq_bug_minimizer_results_action :
 val merge_pull_request_action :
   bot_info:Bot_info.t -> ?t:float -> GitHub_types.comment_info -> unit Lwt.t
 
+val run_bench : bot_info:Bot_info.t -> GitHub_types.comment_info -> unit Lwt.t
+
 val run_ci_action :
      bot_info:Bot_info.t
   -> comment_info:GitHub_types.comment_info

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -56,7 +56,8 @@ let callback _conn req body =
     if
       string_match
         ~regexp:
-          (f "@%s:? [Mm]inimize[^`]*```[^\n]*\n\\(\\(.\\|\n\\)+\\)" bot_name)
+          ( f "@%s:? [Mm]inimize[^`]*```[^\n]*\n\\(\\(.\\|\n\\)+\\)"
+          @@ Str.quote bot_name )
         body
     then Some (Str.matched_group 1 body |> extract_minimize_file)
     else None
@@ -67,8 +68,9 @@ let callback _conn req body =
        the tagging to "@`coqbot minimize foo`" so that the matching
        below doesn't pick up the name *)
     Str.global_replace
-      (Str.regexp (f "\\(`\\|<code>\\)@%s " (Str.quote bot_name)))
-      (f "@\\1%s " bot_name) body
+      (Str.regexp (f "\\(`\\|<code>\\)@%s " @@ Str.quote bot_name))
+      (f "@\\1%s " @@ Str.quote bot_name)
+      body
   in
   (* print_endline "Request received."; *)
   match Uri.path (Request.uri req) with
@@ -231,7 +233,8 @@ let callback _conn req body =
               if
                 string_match
                   ~regexp:
-                    (f "@%s:? [Cc][Ii][- ][Mm]inimize:?\\([^\n]*\\)" bot_name)
+                    ( f "@%s:? [Cc][Ii][- ][Mm]inimize:?\\([^\n]*\\)"
+                    @@ Str.quote bot_name )
                   body
               then (
                 let requests =
@@ -251,15 +254,15 @@ let callback _conn req body =
               else if
                 string_match
                   ~regexp:
-                    (f
-                       "@%s:? resume [Cc][Ii][- \
-                        ][Mm]inimiz\\(e\\|ation\\):?\\([^\n\
-                        ]*\\)\n\
-                        +```[^\n\
-                        ]*\n\
-                        \\(\\(.\\|\n\
-                        \\)+\\)"
-                       bot_name )
+                    ( f
+                        "@%s:? resume [Cc][Ii][- \
+                         ][Mm]inimiz\\(e\\|ation\\):?\\([^\n\
+                         ]*\\)\n\
+                         +```[^\n\
+                         ]*\n\
+                         \\(\\(.\\|\n\
+                         \\)+\\)"
+                    @@ Str.quote bot_name )
                   body
               then (
                 let requests, bug_file_contents =
@@ -281,7 +284,9 @@ let callback _conn req body =
                 Server.respond_string ~status:`OK
                   ~body:"Handling CI minimization resumption." () )
               else if
-                string_match ~regexp:(f "@%s:? [Rr]un CI now" bot_name) body
+                string_match
+                  ~regexp:(f "@%s:? [Rr]un CI now" @@ Str.quote bot_name)
+                  body
                 && comment_info.issue.pull_request
               then
                 init_git_bare_repository ~bot_info
@@ -292,7 +297,9 @@ let callback _conn req body =
                   (run_ci_action ~comment_info ~gitlab_mapping ~github_mapping
                      ~signed )
               else if
-                string_match ~regexp:(f "@%s:? [Mm]erge now" bot_name) body
+                string_match
+                  ~regexp:(f "@%s:? [Mm]erge now" @@ Str.quote bot_name)
+                  body
                 && comment_info.issue.pull_request
                 && String.equal comment_info.issue.issue.owner "coq"
                 && String.equal comment_info.issue.issue.repo "coq"
@@ -308,7 +315,9 @@ let callback _conn req body =
                   ~body:(f "Received a request to merge the PR.")
                   () )
               else if
-                string_match ~regexp:(f "@%s:? [Bb]ench" bot_name) body
+                string_match
+                  ~regexp:(f "@%s:? [Bb]ench" @@ Str.quote bot_name)
+                  body
                 && comment_info.issue.pull_request
                 && String.equal comment_info.issue.issue.owner "coq"
                 && String.equal comment_info.issue.issue.repo "coq"

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -307,6 +307,22 @@ let callback _conn req body =
                 Server.respond_string ~status:`OK
                   ~body:(f "Received a request to merge the PR.")
                   () )
+              else if
+                string_match ~regexp:(f "@%s:? [Bb]ench" bot_name) body
+                && comment_info.issue.pull_request
+                && String.equal comment_info.issue.issue.owner "coq"
+                && String.equal comment_info.issue.issue.repo "coq"
+                && signed
+              then (
+                (fun () ->
+                  action_as_github_app ~bot_info ~key ~app_id
+                    ~owner:comment_info.issue.issue.owner
+                    ~repo:comment_info.issue.issue.repo (run_bench comment_info)
+                  )
+                |> Lwt.async ;
+                Server.respond_string ~status:`OK
+                  ~body:(f "Received a request to start the bench.")
+                  () )
               else
                 Server.respond_string ~status:`OK
                   ~body:(f "Unhandled comment: %s" body)


### PR DESCRIPTION
We can now tell coqbot to start the bench in a PR with `@coqbot bench`.

I haven't tested the regex fully so we need to try it out before deploying fully like usual.