### PR TITLE
thunk merge_pull_request since optional args cannot be deleted otherwise

### DIFF
--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -58,8 +58,8 @@ let close_pull_request ~bot_info ~pr_id =
   | Error err ->
       Stdio.print_endline (f "Error while closing PR: %s" err)
 
-let merge_pull_request ~bot_info ?merge_method ?commit_headline ?commit_body
-    ~pr_id =
+let merge_pull_request ~bot_info ?merge_method ?commit_headline
+    ?commit_body ~pr_id () =
   let merge_method =
     Option.map merge_method ~f:(function
       | MERGE ->

--- a/bot-components/GitHub_mutations.mli
+++ b/bot-components/GitHub_mutations.mli
@@ -19,6 +19,7 @@ val merge_pull_request :
   -> ?commit_headline:string
   -> ?commit_body:string
   -> pr_id:id
+  -> unit
   -> unit Lwt.t
 
 val create_check_run :

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -1793,7 +1793,7 @@ let rec merge_pull_request_action ~bot_info ?(t = 1.) comment_info =
                             ~f:(fun s r -> s ^ f "Ack-by: %s\n" r)
                         ^ f "Co-authored-by: %s <%s@users.noreply.github.com>\n"
                             comment_info.author comment_info.author )
-                      ~merge_method:MERGE
+                      ~merge_method:MERGE ()
                     >>= fun () ->
                     match
                       List.fold_left ~init:[] reviews_info.files


### PR DESCRIPTION
I'm trying this on a newer version of OCaml (4.12.1) and there is a warning about optional arguments that cannot be erased. Having a look at GitHub_mutations.merge_pull_requests there is no way for OCaml to understand a partial application. In order to fix this we just need to add a thunk.