### PR TITLE
Change expiration date properly

### DIFF
--- a/bot-components/GitHub_app.ml
+++ b/bot-components/GitHub_app.ml
@@ -23,7 +23,7 @@ let make_jwt ~key ~app_id =
   let issuedAt = Unix.time () |> Int.of_float in
   let payload =
     f {|{ "iat": %d, "exp": %d, "iss": %d }|} issuedAt
-      (issuedAt + (55 * 10))
+      (issuedAt + (60 * 8))
       app_id
   in
   match (base64 header, base64 payload) with


### PR DESCRIPTION
I mistakenly wrote 55*10 instead of 60*8 since it's not 55 minutes instead of 60 but 8 minutes instead of 10

A safe way would be, if you want me to try it, to 

> date && curl -I https://api.github.com | grep -Fi "date"

Read the two dates, compute the difference in time and create the expected expiration date for the token accordingly. This way, it doesn't matter if your computer is way out of sync, you'll always be able to provide GitHub with the proper dates.