### PR TITLE
Account for new pipeline status: created.

### DIFF
--- a/src/actions.ml
+++ b/src/actions.ml
@@ -1525,7 +1525,7 @@ let pipeline_action ~bot_info pipeline_info ~gitlab_mapping : unit Lwt.t =
       in
       let state, status, conclusion, title, summary_top =
         match pipeline_info.state with
-        | "pending" ->
+        | "created" | "pending" ->
             ("pending", QUEUED, None, "Pipeline is pending on GitLab CI", None)
         | "running" ->
             ( "pending"


### PR DESCRIPTION
Should avoid issues like the one observed at: https://github.com/coq/coq/pull/15986/checks?check_run_id=6270508750