### PR TITLE
Add functionality to bench native

### DIFF
--- a/bot-components/GitLab_mutations.ml
+++ b/bot-components/GitLab_mutations.ml
@@ -1,4 +1,6 @@
+open Base
 open Bot_info
+open Utils
 
 let generic_retry ~bot_info ~url_part =
   let uri =
@@ -13,11 +15,22 @@ let retry_job ~bot_info ~project_id ~build_id =
       ( "projects/" ^ Int.to_string project_id ^ "/jobs/"
       ^ Int.to_string build_id )
 
-let play_job ~bot_info ~project_id ~build_id =
+let play_job ~bot_info ~project_id ~build_id ?(key_value_pairs = []) () =
   let uri =
     Uri.of_string
     @@ Printf.sprintf "https://gitlab.com/api/v4/projects/%d/jobs/%d/play"
          project_id build_id
   in
   let gitlab_header = [("Private-Token", bot_info.gitlab_token)] in
-  Utils.send_request ~body:Cohttp_lwt.Body.empty ~uri gitlab_header ~bot_info
+  let body =
+    match key_value_pairs with
+    | [] ->
+        Cohttp_lwt.Body.empty
+    | _ ->
+        key_value_pairs
+        |> List.map ~f:(fun (k, v) -> f {|{ "key": "%s", "value": "%s" }|} k v)
+        |> String.concat ~sep:","
+        |> f {|{ "job_variables_attributes": [%s] }|}
+        |> Cohttp_lwt.Body.of_string
+  in
+  Utils.send_request ~body ~uri gitlab_header ~bot_info

--- a/bot-components/GitLab_mutations.mli
+++ b/bot-components/GitLab_mutations.mli
@@ -4,4 +4,9 @@ val retry_job :
 val generic_retry : bot_info:Bot_info.t -> url_part:string -> unit Lwt.t
 
 val play_job :
-  bot_info:Bot_info.t -> project_id:int -> build_id:int -> unit Lwt.t
+     bot_info:Bot_info.t
+  -> project_id:int
+  -> build_id:int
+  -> ?key_value_pairs:(string * string) list
+  -> unit
+  -> unit Lwt.t

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -2629,7 +2629,7 @@ let coq_check_stale_pr ~bot_info ~owner ~repo ~after ~throttle =
   in
   apply_after_label ~bot_info ~owner ~repo ~after ~label ~action ~throttle ()
 
-let run_bench ~bot_info comment_info =
+let run_bench ~bot_info ?key_value_pairs comment_info =
   (* Do we want to use this more often? *)
   let open Lwt.Syntax in
   let pr = comment_info.issue in
@@ -2692,7 +2692,7 @@ let run_bench ~bot_info comment_info =
   match (allowed_to_bench, process_summary) with
   | Ok true, Ok (build_id, project_id) ->
       (* Permission to bench has been granted *)
-      GitLab_mutations.play_job ~bot_info ~project_id ~build_id
+      GitLab_mutations.play_job ~bot_info ~project_id ~build_id ?key_value_pairs ()
   | Error err, _ | _, Error err ->
       GitHub_mutations.post_comment ~bot_info ~message:err ~id:pr.id
       >>= GitHub_mutations.report_on_posting_comment

--- a/src/actions.mli
+++ b/src/actions.mli
@@ -32,7 +32,11 @@ val coq_bug_minimizer_results_action :
 val merge_pull_request_action :
   bot_info:Bot_info.t -> ?t:float -> GitHub_types.comment_info -> unit Lwt.t
 
-val run_bench : bot_info:Bot_info.t -> GitHub_types.comment_info -> unit Lwt.t
+val run_bench :
+     bot_info:Bot_info.t
+  -> ?key_value_pairs:(string * string) list
+  -> GitHub_types.comment_info
+  -> unit Lwt.t
 
 val run_ci_action :
      bot_info:Bot_info.t

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -332,6 +332,26 @@ let callback _conn req body =
                   () )
               else if
                 string_match
+                  ~regexp:(f "@%s:? [Bb]ench native" @@ Str.quote bot_name)
+                  body
+                && comment_info.issue.pull_request
+                && String.equal comment_info.issue.issue.owner "coq"
+                && String.equal comment_info.issue.issue.repo "coq"
+                && signed
+              then (
+                (fun () ->
+                  action_as_github_app ~bot_info ~key ~app_id
+                    ~owner:comment_info.issue.issue.owner
+                    ~repo:comment_info.issue.issue.repo
+                    (run_bench
+                       ~key_value_pairs:[("coq_native", "yes")]
+                       comment_info ) )
+                |> Lwt.async ;
+                Server.respond_string ~status:`OK
+                  ~body:(f "Received a request to start the bench.")
+                  () )
+              else if
+                string_match
                   ~regexp:(f "@%s:? [Bb]ench" @@ Str.quote bot_name)
                   body
                 && comment_info.issue.pull_request


### PR DESCRIPTION
We should now be able to do `@coqbot bench native`. Once https://github.com/coq/coq/pull/16679 lands.

This defo needs testing since the GitLab docs on the env var for the job are so poor.