### PR TITLE
thunk Config.github_private_key

### DIFF
--- a/src/bot.ml
+++ b/src/bot.ml
@@ -24,7 +24,7 @@ let daily_schedule_secret = Config.daily_schedule_secret toml_data
 
 let bot_name = Config.bot_name toml_data
 
-let key = Config.github_private_key
+let key = Config.github_private_key ()
 
 let app_id = Config.github_app_id toml_data
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -92,7 +92,7 @@ let github_app_id toml_data =
 
 (*let string_of_file_path path = Stdio.In_channel.(with_file path ~f:input_all)*)
 
-let github_private_key =
+let github_private_key () =
   (*string_of_file_path "./github.private-key.pem"*)
   match
     let private_k = Sys.getenv_exn "GITHUB_PRIVATE_KEY" in

--- a/src/config.mli
+++ b/src/config.mli
@@ -26,7 +26,7 @@ val bot_email : Toml.Types.table -> string
 
 val github_app_id : Toml.Types.table -> int
 
-val github_private_key : Mirage_crypto_pk.Rsa.priv
+val github_private_key : unit -> Mirage_crypto_pk.Rsa.priv
 
 val make_mappings_table :
      Toml.Types.value Toml.Types.Table.t


### PR DESCRIPTION
This makes it only be called when needed. Otherwise it gets called during linking and that affects unreleated things.

