### PR TITLE
Add ppx_expect as a dependency

### DIFF
--- a/coq-bot.opam
+++ b/coq-bot.opam
@@ -20,6 +20,7 @@ depends: [
   "yojson" {>= "1.7.0"}
   "bot-components" {dev}
   "toml" {>= "7.0.0"}
+  "ppx_expect" {>= "v0.15.1"}
   "odoc" {>= "1.5.2" & with-doc}
 ]
 build: [

--- a/default.nix
+++ b/default.nix
@@ -30,6 +30,7 @@ pkgs.stdenv.mkDerivation rec {
     eqaf
     x509
     cstruct
+    ppx_expect
     odoc
   ];
 

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   (yojson (>= 1.7.0))
   (bot-components :dev)
   (toml (>= 7.0.0))
+  (ppx_expect (>= v0.15.1))
   (odoc (and (>= 1.5.2) :with-doc)))
 )
 (package

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -1,12 +1,13 @@
-open Actions
 open Base
-open Bot_components
 open Cohttp
 open Cohttp_lwt_unix
+open Lwt.Infix
+open Bot_components
+open Botlib
+open Actions
 open Git_utils
 open Github_installations
 open Helpers
-open Lwt.Infix
 
 let toml_data = Config.toml_of_file (Sys.get_argv ()).(1)
 

--- a/src/config.ml
+++ b/src/config.ml
@@ -121,7 +121,7 @@ let parse_mappings mappings =
            | Some gh, Some gl ->
                Some (gh, gl)
            | _, _ ->
-               None ))
+               None ) )
   in
   let assoc_rev = List.map assoc ~f:(fun (gh, gl) -> (gl, gh)) in
   let get_table t =

--- a/src/dune
+++ b/src/dune
@@ -1,10 +1,19 @@
+(library
+ (name botlib)
+ (libraries base bot-components cohttp-lwt-unix mirage-crypto
+   mirage-crypto-rng mirage-crypto-rng.lwt stdio toml yojson)
+ (modules :standard \ bot)
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect)))
+
 (executable
  (name bot)
  (public_name bot)
  (package coq-bot)
+ (modules bot)
  (promote (until-clean))
- (libraries base bot-components cohttp-lwt-unix mirage-crypto
-   mirage-crypto-rng mirage-crypto-rng.lwt stdio toml yojson))
+ (libraries botlib))
 
 (env
  (dev


### PR DESCRIPTION
This lets us write inline expectation tests which is quite useful especially in a hard to test application like coqbot.

Depends on #244.