### PR TITLE
Allow customization of Coq version

### DIFF
--- a/coq_bug_minimizer.sh
+++ b/coq_bug_minimizer.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# usage: coq_bug_minimizer.sh 'script' comment_thread_id comment_author github_token bot_name bot_domain owner repo
+# usage: coq_bug_minimizer.sh 'script' comment_thread_id comment_author github_token bot_name bot_domain owner repo coq_version ocaml_version
 
 set -ex
 
-if [ $# != 8 ]; then >&2 echo Bad argument count; exit 1; fi
+if [ $# != 10 ]; then >&2 echo Bad argument count; exit 1; fi
 
 script=$1
 comment_thread_id=$2
@@ -14,6 +14,8 @@ bot_name=$5
 bot_domain=$6
 owner=$7
 repo=$8
+coq_version=$9
+ocaml_version=${10}
 branch_id=$(($(od -A n -t uI -N 5 /dev/urandom | tr -d ' ')))
 repo_name="coq-community/run-coq-bug-minimizer"
 branch_name="run-coq-bug-minimizer-$branch_id"
@@ -25,6 +27,8 @@ git worktree add "$wtree" "$branch_name"
 pushd "$wtree"
 
 printf "%s %s %s %s %s %s" "$comment_thread_id" "$comment_author" "$repo_name" "$branch_name" "$owner" "$repo" > coqbot-request-stamp
+test -z "${coq_version}" || sed -i 's~^\(\s*\)[^:\s]*coq_version:.*$~\1coq_version: '"'${coq_version}'~" .github/workflows/main.yml
+test -z "${ocaml_version}" || sed -i 's~^\(\s*\)[^:\s]*ocaml_version:.*$~\1ocaml_version: '"'${ocaml_version}'~" .github/workflows/main.yml
 printf "%s\n" "$script" > coqbot.sh
 sed -i 's/\r$//g' coqbot.sh
 echo "https://$bot_domain/coq-bug-minimizer" > coqbot.url

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -1843,7 +1843,7 @@ let run_coq_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
   let getopt opt =
     if
       string_match
-        ~regexp:(f " %s\\(\\.\\|[ -]\\|: \\)\\([^ ]+\\) " opt)
+        ~regexp:(f " %s\\(\\.\\|[ =:-]\\|: \\)[vV]?\\([^ ]+\\) " opt)
         options
     then Str.matched_group 2 options
     else ""

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -1836,9 +1836,29 @@ let pipeline_action ~bot_info pipeline_info ~gitlab_mapping : unit Lwt.t =
                   Lwt.return_unit ) ) )
 
 let run_coq_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
-    ~owner ~repo =
+    ~owner ~repo ~options =
+  let options =
+    " " ^ options ^ " " |> Str.global_replace (Str.regexp "[\n\r\t]") " "
+  in
+  let getopt opt =
+    if
+      string_match
+        ~regexp:(f " %s\\(\\.\\|[ -]\\|: \\)\\([^ ]+\\) " opt)
+        options
+    then Str.matched_group 2 options
+    else ""
+  in
+  let coq_version = getopt "[Cc]oq" in
+  let ocaml_version = getopt "[Oo][Cc]aml" in
+  Lwt_io.printlf
+    "Parsed options for the bug minimizer at %s/%s@%s from '%s' into \
+     {coq_version: '%s'; ocaml_version: '%s'}"
+    owner repo
+    (GitHub_ID.to_string comment_thread_id)
+    options coq_version ocaml_version
+  >>= fun () ->
   git_coq_bug_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
-    ~owner ~repo
+    ~owner ~repo ~coq_version ~ocaml_version
   >>= function
   | Ok () ->
       GitHub_mutations.post_comment ~id:comment_thread_id
@@ -1898,8 +1918,11 @@ let coq_bug_minimizer_resume_ci_minimization_action ~bot_info ~key ~app_id body
       ; pr_number ] -> (
         message |> String.split ~on:'\n'
         |> function
-        | docker_image :: target :: opam_switch :: failing_urls :: passing_urls
-          :: base :: head :: bug_file_lines ->
+        | docker_image
+          :: target
+             :: opam_switch
+                :: failing_urls
+                   :: passing_urls :: base :: head :: bug_file_lines ->
             (let bug_file_contents = String.concat ~sep:"\n" bug_file_lines in
              fun () ->
                init_git_bare_repository ~bot_info
@@ -2351,7 +2374,7 @@ let run_ci_action ~bot_info ~comment_info ?full_ci ~gitlab_mapping
             Lwt_io.printl "Unauthorized user: doing nothing." |> Lwt_result.ok
           )
     |> Fn.flip Lwt_result.bind_lwt_err (fun err ->
-           Lwt_io.printf "Error: %s\n" err ) )
+           Lwt_io.printf "Error: %s\n" err ))
     >>= fun _ -> Lwt.return_unit )
   |> Lwt.async ;
   Server.respond_string ~status:`OK

--- a/src/actions.mli
+++ b/src/actions.mli
@@ -19,6 +19,7 @@ val run_coq_minimizer :
   -> comment_author:string
   -> owner:string
   -> repo:string
+  -> options:string
   -> unit Lwt.t
 
 val coq_bug_minimizer_results_action :

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -57,10 +57,13 @@ let callback _conn req body =
     if
       string_match
         ~regexp:
-          ( f "@%s:? [Mm]inimize[^`]*```[^\n]*\n\\(\\(.\\|\n\\)+\\)"
+          ( f "@%s:? [Mm]inimize\\([^`]*\\)```[^\n]*\n\\(\\(.\\|\n\\)+\\)"
           @@ Str.quote bot_name )
         body
-    then Some (Str.matched_group 1 body |> extract_minimize_file)
+    then
+      Some
+        ( Str.matched_group 1 body
+        , Str.matched_group 2 body |> extract_minimize_file )
     else None
   in
   let strip_quoted_bot_name body =
@@ -184,7 +187,7 @@ let callback _conn req body =
       | Ok (_, IssueOpened ({body= Some body} as issue_info)) -> (
           let body = body |> Helpers.trim_comments |> strip_quoted_bot_name in
           match coqbot_minimize_text_of_body body with
-          | Some script ->
+          | Some (options, script) ->
               (fun () ->
                 init_git_bare_repository ~bot_info
                 >>= fun () ->
@@ -192,8 +195,8 @@ let callback _conn req body =
                   ~owner:issue_info.issue.owner ~repo:issue_info.issue.repo
                   (run_coq_minimizer ~script ~comment_thread_id:issue_info.id
                      ~comment_author:issue_info.user
-                     ~owner:issue_info.issue.owner ~repo:issue_info.issue.repo )
-                )
+                     ~owner:issue_info.issue.owner ~repo:issue_info.issue.repo
+                     ~options ) )
               |> Lwt.async ;
               Server.respond_string ~status:`OK ~body:"Handling minimization."
                 ()
@@ -206,7 +209,7 @@ let callback _conn req body =
             comment_info.body |> Helpers.trim_comments |> strip_quoted_bot_name
           in
           match coqbot_minimize_text_of_body body with
-          | Some script ->
+          | Some (options, script) ->
               (fun () ->
                 init_git_bare_repository ~bot_info
                 >>= fun () ->
@@ -217,7 +220,7 @@ let callback _conn req body =
                      ~comment_thread_id:comment_info.issue.id
                      ~comment_author:comment_info.author
                      ~owner:comment_info.issue.issue.owner
-                     ~repo:comment_info.issue.issue.repo ) )
+                     ~repo:comment_info.issue.issue.repo ~options ) )
               |> Lwt.async ;
               Server.respond_string ~status:`OK ~body:"Handling minimization."
                 ()
@@ -344,8 +347,7 @@ let callback _conn req body =
                   action_as_github_app ~bot_info ~key ~app_id
                     ~owner:comment_info.issue.issue.owner
                     ~repo:comment_info.issue.issue.repo
-                    (run_bench
-                       ~key_value_pairs:[("coq_native", "yes")]
+                    (run_bench ~key_value_pairs:[("coq_native", "yes")]
                        comment_info ) )
                 |> Lwt.async ;
                 Server.respond_string ~status:`OK

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -61,9 +61,11 @@ let callback _conn req body =
           @@ Str.quote bot_name )
         body
     then
-      Some
-        ( Str.matched_group 1 body
-        , Str.matched_group 2 body |> extract_minimize_file )
+      (* avoid internal server errors from unclear execution order *)
+      let options, body =
+        (Str.matched_group 1 body, Str.matched_group 2 body)
+      in
+      Some (options, body |> extract_minimize_file)
     else None
   in
   let strip_quoted_bot_name body =

--- a/src/git_utils.ml
+++ b/src/git_utils.ml
@@ -134,6 +134,8 @@ let git_coq_bug_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
   (* To push a new branch we need to identify as coqbot the GitHub
      user, who is a collaborator on the run-coq-bug-minimizer repo,
      not coqbot the GitHub App *)
+  let coq_version = "" in
+  let ocaml_version = "" in
   Stdlib.Filename.quote_command "./coq_bug_minimizer.sh"
     [ script
     ; GitHub_ID.to_string comment_thread_id
@@ -142,7 +144,9 @@ let git_coq_bug_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
     ; bot_info.name
     ; bot_info.domain
     ; owner
-    ; repo ]
+    ; repo
+    ; coq_version
+    ; ocaml_version ]
   |> execute_cmd
 
 let git_run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo ~pr_number

--- a/src/git_utils.ml
+++ b/src/git_utils.ml
@@ -130,12 +130,10 @@ let git_test_modified ~base ~head pattern =
       Error (f "%s stopped by signal %d." command signal)
 
 let git_coq_bug_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
-    ~owner ~repo =
+    ~owner ~repo ~coq_version ~ocaml_version =
   (* To push a new branch we need to identify as coqbot the GitHub
      user, who is a collaborator on the run-coq-bug-minimizer repo,
      not coqbot the GitHub App *)
-  let coq_version = "" in
-  let ocaml_version = "" in
   Stdlib.Filename.quote_command "./coq_bug_minimizer.sh"
     [ script
     ; GitHub_ID.to_string comment_thread_id

--- a/src/git_utils.mli
+++ b/src/git_utils.mli
@@ -42,6 +42,8 @@ val git_coq_bug_minimizer :
   -> comment_author:string
   -> owner:string
   -> repo:string
+  -> coq_version:string
+  -> ocaml_version:string
   -> (unit, string) result Lwt.t
 
 val git_run_ci_minimization :


### PR DESCRIPTION
Not entirely clear what the protocol should be, see also #183.  We
currently allow things like `coq-8.14` and `coq.dev` and `coq: dev` and
`ocaml: 4.11`, etc.