### PR TITLE
Improve minimization logic around scripts and files

### DIFF
--- a/src/actions.mli
+++ b/src/actions.mli
@@ -12,9 +12,13 @@ val pipeline_action :
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
   -> unit Lwt.t
 
+type coqbot_minimize_script_data =
+  | MinimizeScript of {quote_kind: string; body: string}
+  | MinimizeAttachment of {description: string; url: string}
+
 val run_coq_minimizer :
      bot_info:Bot_info.t
-  -> script:string
+  -> script:coqbot_minimize_script_data
   -> comment_thread_id:GitHub_ID.t
   -> comment_author:string
   -> owner:string


### PR DESCRIPTION
We now assume that `@coqbot minimize` is followed by a Coq file, not a bash script, unless the user begins with ` ```sh` or ` ```bash` or the script begins with `#!`.

Additionally, we also allow the user to say `@coqbot minimize [text](url)`, and use the `handle-web-file.sh` script in the run-coq-bug-minimizer to automatically download `url` and automagically figure out how to build run coq on it.  (Currently there's support for uncompressing archives, running single .v files, renaming text files to .v if there's no archive, finding _CoqProject, and using autogen, configure, and make to build archives if there's a single makefile.)

Fixes #256