### PR TITLE
Mirror feature + multi-GitLab instance support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,14 +253,21 @@ Once you finish the installation, follow these steps:
   By default, **@coqbot** considers that both GitHub and GitLab repositories
   share the same URL except for the "lab" replacing the "hub" part. If
   that is not the case, assuming you created a GitLab repository whose
-  URL is <https://gitlab.com/owner/repo/>, add a file `coqbot.toml` at
+  URL is <https://mygitlab.example.com/owner/repo/>, add a file `coqbot.toml` at
   the root of your GitHub repository and in its default branch (most often
   named `master`), containing:
   ```
   [mapping]
   gitlab = "owner/repo"
+  gitlab_domain = "mygitlab.example.com"
   ```
-  If you use other instance of **@coqbot**, this repository-specific
+  If omitted, the `gitlab_domain` value defaults to `"gitlab.com"`.
+  Note that the value of `gitlab_domain` must be a supported GitLab
+  instance, i.e., it needs to be defined in the bot's own configuration
+  file (check [coqbot-config.toml](coqbot-config.toml) for the coqbot
+  instance configuration).
+
+  If you use another instance of **@coqbot**, this repository-specific
   configuration file becomes `BOT_NAME.toml` where `BOT_NAME` is the name
   of the bot.
 
@@ -345,11 +352,14 @@ to [Heroku](https://www.heroku.com/). Simply follow the official
 The bot will need to read a few environment variables so make sure
 these are configured in your Heroku app:
 
-- `GITLAB_ACCESS_TOKEN`
-- `GITHUB_ACCESS_TOKEN`
-- `GITHUB_WEBHOOK_SECRET`
+- `GITHUB_ACCESS_TOKEN` (can also be defined in the configuration file as `github.api_token`)
+- `GITLAB_ACCESS_TOKEN` (can also be defined for each GitLab instance through the configuration file as `api_token` or through an environment variable whose name is defined in the configuration file as `api_token_env_var`)
+- `GITHUB_WEBHOOK_SECRET` (can also be defined in the configuration file as `github.webhook_secret`)
+- `GITLAB_WEBHOOK_SECRET` (can also be defined in the configuration file as `gitlab.webhook_secret`, will default to `GITHUB_WEBHOOK_SECRET` if not defined)
+- `DAILY_SCHEDULE_SECRET` (can also be defined in the configuration file as `github.daily_schedule_secret`, will default to `GITHUB_WEBHOOK_SECRET` if not defined)
+- `GITHUB_APP_ID` (can also be defined in the configuration file as `github.app_id`)
 - `GITHUB_PRIVATE_KEY` (a private key of your GitHub app)
-- `GITHUB_APP_ID` (your GitHub App ID)
+- `PORT` (can also be defined in the configuration file as `server.port`)
 
 Then, you must configure the bot with a configuration file. Here is an example
 to adapt to your needs [`example-config.toml`](example-config.toml)).

--- a/README.md
+++ b/README.md
@@ -221,14 +221,24 @@ Once you finish the installation, follow these steps:
 
 - Create a repository on GitLab.com which will be used to run CI jobs.
 
-  The bot will only take care of mirroring the PRs and reporting
-  status checks back so you may still want to activate the mirroring
-  feature for the main branches.  To do so, the easiest way is to
-  choose the "CI/CD for external repo" option when creating the GitLab
-  repository.  However, you should opt to give the repo by URL rather
-  than with the GitHub button, because we won't need GitLab's own
-  status check reporting feature. (If it is already activated, you can
-  disable this integration in the "Settings" / "Integration" menu).
+  By default, the bot will only take care of mirroring the PRs and
+  reporting status checks back. So you may still want to activate:
+
+  - either GitLab's mirroring feature for the main branches.
+    (A drawback is the
+    [sync lag](https://docs.gitlab.com/ee/user/project/repository/mirror/#update-a-mirror)
+    (between 5' and 30') that occurs with this pull-based mirroring.)
+    If you do so, the easiest way is to choose the "CI/CD for external
+    repo" option when creating the GitLab repository.  However, you
+    should opt to give the repo by URL rather than with the GitHub
+    button, because we won't need GitLab's own status check reporting
+    feature. (If it is already activated, you can disable this
+    integration in the "Settings" / "Integration" menu).
+
+  - or **@coqbot**'s mirroring feature (it is a push-based mirroring).
+    For now, this requires hardcoding the GitHub / GitLab mapping in
+    the bot's source code.  Please open an issue if you would like to
+    use this feature. We plan to make this configurable in the future.
 
 - In your GitLab repository:
 

--- a/bot-components/Bot_info.ml
+++ b/bot-components/Bot_info.ml
@@ -1,8 +1,10 @@
+open Base
+
 type t =
-  { gitlab_token: string
+  { gitlab_instances: (string, string * string) Hashtbl.t
   ; github_pat: string
   ; github_install_token: string option
-  ; name: string
+  ; github_name: string
   ; email: string
   ; domain: string
   ; app_id: int }
@@ -13,3 +15,15 @@ let github_token bot_info =
       t
   | None ->
       bot_info.github_pat
+
+let gitlab_name_and_token bot_info gitlab_domain =
+  match Hashtbl.find bot_info.gitlab_instances gitlab_domain with
+  | Some t ->
+      Ok t
+  | None ->
+      Error
+        ( "I don't know about GitLab domain " ^ gitlab_domain
+        ^ " (not in my configuration file)" )
+
+let gitlab_token bot_info gitlab_domain =
+  gitlab_name_and_token bot_info gitlab_domain |> Result.map ~f:snd

--- a/bot-components/Bot_info.mli
+++ b/bot-components/Bot_info.mli
@@ -1,10 +1,14 @@
 type t =
-  { gitlab_token: string
+  { gitlab_instances: (string, string * string) Base.Hashtbl.t
   ; github_pat: string
   ; github_install_token: string option
-  ; name: string
+  ; github_name: string
   ; email: string
   ; domain: string
   ; app_id: int }
 
 val github_token : t -> string
+
+val gitlab_token : t -> string -> (string, string) Result.t
+
+val gitlab_name_and_token : t -> string -> (string * string, string) Result.t

--- a/bot-components/GitHub_app.ml
+++ b/bot-components/GitHub_app.ml
@@ -39,13 +39,13 @@ let make_jwt ~key ~app_id =
 
 let get ~bot_info ~token ~url =
   Stdio.print_endline ("Making get request to " ^ url) ;
-  let headers = headers ~bot_info (github_headers token) in
+  let headers = headers (github_headers token) bot_info.Bot_info.github_name in
   Client.get ~headers (Uri.of_string url)
   >>= fun (_response, body) -> Cohttp_lwt.Body.to_string body
 
 let post ~bot_info ~body ~token ~url =
   Stdio.print_endline ("Making post request to " ^ url) ;
-  let headers = headers ~bot_info (github_headers token) in
+  let headers = headers (github_headers token) bot_info.Bot_info.github_name in
   let body =
     (match body with None -> "{}" | Some json -> Yojson.to_string json)
     |> Cohttp_lwt.Body.of_string

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -16,11 +16,11 @@ let mv_card_to_column ~bot_info ({card_id; column_id} : mv_card_to_column_input)
   |> serializeVariables |> variablesToJson
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
-  >|= function
+  >>= function
   | Ok _ ->
-      ()
+      Lwt.return_unit
   | Error err ->
-      Stdio.print_endline (f "Error while moving project card: %s" err)
+      Lwt_io.printlf "Error while moving project card: %s" err
 
 let post_comment ~bot_info ~id ~message =
   let open GitHub_GraphQL.PostComment in
@@ -49,11 +49,11 @@ let update_milestone ~bot_info ~issue ~milestone =
   |> serializeVariables |> variablesToJson
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
-  >|= function
+  >>= function
   | Ok _ ->
-      ()
+      Lwt.return_unit
   | Error err ->
-      Stdio.print_endline (f "Error while updating milestone: %s" err)
+      Lwt_io.printlf "Error while updating milestone: %s" err
 
 let close_pull_request ~bot_info ~pr_id =
   let open GitHub_GraphQL.ClosePullRequest in
@@ -61,11 +61,11 @@ let close_pull_request ~bot_info ~pr_id =
   |> serializeVariables |> variablesToJson
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
-  >|= function
+  >>= function
   | Ok _ ->
-      ()
+      Lwt.return_unit
   | Error err ->
-      Stdio.print_endline (f "Error while closing PR: %s" err)
+      Lwt_io.printlf "Error while closing PR: %s" err
 
 let merge_pull_request ~bot_info ?merge_method ?commit_headline ?commit_body
     ~pr_id () =
@@ -85,11 +85,11 @@ let merge_pull_request ~bot_info ?merge_method ?commit_headline ?commit_body
   |> serializeVariables |> variablesToJson
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
-  >|= function
+  >>= function
   | Ok _ ->
-      ()
+      Lwt.return_unit
   | Error err ->
-      Stdio.print_endline (f "Error while merging PR: %s" err)
+      Lwt_io.printlf "Error while merging PR: %s" err
 
 let reflect_pull_request_milestone ~bot_info issue_closer_info =
   match issue_closer_info.closer.milestone_id with
@@ -182,11 +182,11 @@ let update_check_run ~bot_info ~check_run_id ~repo_id ~conclusion ?details_url
   |> serializeVariables |> variablesToJson
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
-  >|= function
+  >>= function
   | Ok _ ->
-      ()
+      Lwt.return_unit
   | Error err ->
-      Stdio.print_endline (f "Error while updating check run: %s" err)
+      Lwt_io.printlf "Error while updating check run: %s" err
 
 let add_labels ~bot_info ~labels ~issue =
   let open GitHub_GraphQL.LabelIssue in
@@ -217,9 +217,6 @@ let update_milestone ~bot_info new_milestone (issue : issue) =
   let uri =
     f "https://api.github.com/repos/%s/%s/issues/%d" issue.owner issue.repo
       issue.number
-    |> (fun url ->
-         Stdio.printf "URL: %s\n" url ;
-         url )
     |> Uri.of_string
   in
   let body =
@@ -250,17 +247,11 @@ let send_status_check ~bot_info ~repo_full_name ~commit ~state ~url ~context
 let add_pr_to_column ~bot_info ~pr_id ~column_id =
   let body =
     f {|{"content_id":%d, "content_type": "PullRequest"}|} pr_id
-    |> (fun body ->
-         Stdio.printf "Body:\n%s\n" body ;
-         body )
     |> Cohttp_lwt.Body.of_string
   in
   let uri =
     "https://api.github.com/projects/columns/" ^ Int.to_string column_id
     ^ "/cards"
-    |> (fun url ->
-         Stdio.printf "URL: %s\n" url ;
-         url )
     |> Uri.of_string
   in
   send_request ~body ~uri

--- a/bot-components/GitHub_mutations.ml
+++ b/bot-components/GitHub_mutations.ml
@@ -4,7 +4,7 @@ open Cohttp_lwt_unix
 open Lwt
 open Utils
 
-let send_graphql_query = GraphQL_query.send_graphql_query ~api:`GitHub
+let send_graphql_query = GraphQL_query.send_graphql_query ~api:GitHub
 
 let mv_card_to_column ~bot_info ({card_id; column_id} : mv_card_to_column_input)
     =
@@ -213,7 +213,7 @@ let remove_labels ~bot_info ~labels ~issue =
 (* TODO: use GraphQL API *)
 
 let update_milestone ~bot_info new_milestone (issue : issue) =
-  let headers = headers (github_header bot_info) ~bot_info in
+  let headers = headers (github_header bot_info) bot_info.github_name in
   let uri =
     f "https://api.github.com/repos/%s/%s/issues/%d" issue.owner issue.repo
       issue.number
@@ -245,7 +245,7 @@ let send_status_check ~bot_info ~repo_full_name ~commit ~state ~url ~context
     "https://api.github.com/repos/" ^ repo_full_name ^ "/statuses/" ^ commit
     |> Uri.of_string
   in
-  send_request ~body ~uri (github_header bot_info) ~bot_info
+  send_request ~body ~uri (github_header bot_info) bot_info.github_name
 
 let add_pr_to_column ~bot_info ~pr_id ~column_id =
   let body =
@@ -265,4 +265,4 @@ let add_pr_to_column ~bot_info ~pr_id ~column_id =
   in
   send_request ~body ~uri
     (project_api_preview_header @ github_header bot_info)
-    ~bot_info
+    bot_info.github_name

--- a/bot-components/GitHub_queries.ml
+++ b/bot-components/GitHub_queries.ml
@@ -4,7 +4,7 @@ open GitHub_types
 open Lwt
 open Utils
 
-let send_graphql_query = GraphQL_query.send_graphql_query ~api:`GitHub
+let send_graphql_query = GraphQL_query.send_graphql_query ~api:GitHub
 
 let extract_backport_info ~(bot_info : Bot_info.t) description :
     full_backport_info option =
@@ -12,7 +12,8 @@ let extract_backport_info ~(bot_info : Bot_info.t) description :
     "https://github.com/[^/]*/[^/]*/projects/[0-9]+#column-\\([0-9]+\\)"
   in
   let regexp =
-    bot_info.name ^ ": backport to \\([^ ]*\\) (request inclusion column: "
+    bot_info.github_name
+    ^ ": backport to \\([^ ]*\\) (request inclusion column: "
     ^ project_column_regexp ^ "; backported column: " ^ project_column_regexp
     ^ "; move rejected PRs to: "
     ^ "https://github.com/[^/]*/[^/]*/milestone/\\([0-9]+\\)" ^ ")"
@@ -29,7 +30,7 @@ let extract_backport_info ~(bot_info : Bot_info.t) description :
           [{backport_to; request_inclusion_column; backported_column}]
       ; rejected_milestone }
   else
-    let begin_regexp = bot_info.name ^ ": \\(.*\\)$" in
+    let begin_regexp = bot_info.github_name ^ ": \\(.*\\)$" in
     let backport_info_unit =
       "backport to \\([^ ]*\\) (request inclusion column: "
       ^ project_column_regexp ^ "; backported column: " ^ project_column_regexp

--- a/bot-components/GitHub_subscriptions.ml
+++ b/bot-components/GitHub_subscriptions.ml
@@ -143,11 +143,12 @@ let push_event_info_of_json json =
   in
   let repo = json |> member "repository" |> member "name" |> to_string in
   let base_ref = json |> member "ref" |> to_string in
+  let head_sha = json |> member "after" |> to_string in
   let commits = json |> member "commits" |> to_list in
   let commits_msg =
     List.map commits ~f:(fun c -> c |> member "message" |> to_string)
   in
-  {owner; repo; base_ref; commits_msg}
+  {owner; repo; base_ref; head_sha; commits_msg}
 
 type msg =
   | IssueOpened of issue_info

--- a/bot-components/GitHub_types.mli
+++ b/bot-components/GitHub_types.mli
@@ -85,7 +85,11 @@ type comment_info =
   ; id: GitHub_ID.t }
 
 type push_info =
-  {owner: string; repo: string; base_ref: string; commits_msg: string list}
+  { owner: string
+  ; repo: string
+  ; base_ref: string
+  ; head_sha: string
+  ; commits_msg: string list }
 
 type check_run_status = COMPLETED | IN_PROGRESS | QUEUED
 

--- a/bot-components/GitLab_mutations.ml
+++ b/bot-components/GitLab_mutations.ml
@@ -2,38 +2,48 @@ open Base
 open Bot_info
 open Utils
 
-let generic_retry ~bot_info ~url_part =
+let generic_retry ~bot_info ~gitlab_domain ~url_part =
   let uri =
-    "https://gitlab.com/api/v4/" ^ url_part ^ "/retry" |> Uri.of_string
+    f "https://%s/api/v4/%s/retry" gitlab_domain url_part |> Uri.of_string
   in
-  let gitlab_header = [("Private-Token", bot_info.gitlab_token)] in
-  Utils.send_request ~body:Cohttp_lwt.Body.empty ~uri gitlab_header ~bot_info
+  match gitlab_name_and_token bot_info gitlab_domain with
+  | Error err ->
+      Lwt_io.printlf "Error when retrying job %s: %s." url_part err
+  | Ok (name, token) ->
+      let gitlab_header = [("Private-Token", token)] in
+      Utils.send_request ~body:Cohttp_lwt.Body.empty ~uri gitlab_header name
 
-let retry_job ~bot_info ~project_id ~build_id =
-  generic_retry ~bot_info
+let retry_job ~bot_info ~gitlab_domain ~project_id ~build_id =
+  generic_retry ~bot_info ~gitlab_domain
     ~url_part:
       ( "projects/" ^ Int.to_string project_id ^ "/jobs/"
       ^ Int.to_string build_id )
 
-let play_job ~bot_info ~project_id ~build_id ?(key_value_pairs = []) () =
+let play_job ~bot_info ~gitlab_domain ~project_id ~build_id
+    ?(key_value_pairs = []) () =
   let uri =
     Uri.of_string
-    @@ Printf.sprintf "https://gitlab.com/api/v4/projects/%d/jobs/%d/play"
+    @@ Printf.sprintf "https://%s/api/v4/projects/%d/jobs/%d/play" gitlab_domain
          project_id build_id
   in
-  let gitlab_header =
-    [ ("Private-Token", bot_info.gitlab_token)
-    ; ("Content-Type", "application/json") ]
-  in
-  let body =
-    match key_value_pairs with
-    | [] ->
-        Cohttp_lwt.Body.empty
-    | _ ->
-        key_value_pairs
-        |> List.map ~f:(fun (k, v) -> f {|{ "key": "%s", "value": "%s" }|} k v)
-        |> String.concat ~sep:","
-        |> f {|{ "job_variables_attributes": [%s] }|}
-        |> Cohttp_lwt.Body.of_string
-  in
-  Utils.send_request ~body ~uri gitlab_header ~bot_info
+  match gitlab_name_and_token bot_info gitlab_domain with
+  | Error err ->
+      Lwt_io.printlf "Error when playing job %d of project %d: %s." build_id
+        project_id err
+  | Ok (name, token) ->
+      let gitlab_header =
+        [("Private-Token", token); ("Content-Type", "application/json")]
+      in
+      let body =
+        match key_value_pairs with
+        | [] ->
+            Cohttp_lwt.Body.empty
+        | _ ->
+            key_value_pairs
+            |> List.map ~f:(fun (k, v) ->
+                   f {|{ "key": "%s", "value": "%s" }|} k v )
+            |> String.concat ~sep:","
+            |> f {|{ "job_variables_attributes": [%s] }|}
+            |> Cohttp_lwt.Body.of_string
+      in
+      Utils.send_request ~body ~uri gitlab_header name

--- a/bot-components/GitLab_mutations.mli
+++ b/bot-components/GitLab_mutations.mli
@@ -1,10 +1,16 @@
 val retry_job :
-  bot_info:Bot_info.t -> project_id:int -> build_id:int -> unit Lwt.t
+     bot_info:Bot_info.t
+  -> gitlab_domain:string
+  -> project_id:int
+  -> build_id:int
+  -> unit Lwt.t
 
-val generic_retry : bot_info:Bot_info.t -> url_part:string -> unit Lwt.t
+val generic_retry :
+  bot_info:Bot_info.t -> gitlab_domain:string -> url_part:string -> unit Lwt.t
 
 val play_job :
      bot_info:Bot_info.t
+  -> gitlab_domain:string
   -> project_id:int
   -> build_id:int
   -> ?key_value_pairs:(string * string) list

--- a/bot-components/GitLab_queries.ml
+++ b/bot-components/GitLab_queries.ml
@@ -1,30 +1,37 @@
 open Base
 open Cohttp_lwt_unix
-open Lwt
 open Bot_info
 open Utils
 
-let send_graphql_query = GraphQL_query.send_graphql_query ~api:`GitLab
+let send_graphql_query ~gitlab_domain =
+  GraphQL_query.send_graphql_query ~api:(GitLab gitlab_domain)
 
-let get_build_trace ~bot_info ~project_id ~build_id =
+let get_build_trace ~bot_info ~gitlab_domain ~project_id ~build_id =
   let uri =
-    "https://gitlab.com/api/v4/projects/" ^ Int.to_string project_id ^ "/jobs/"
-    ^ Int.to_string build_id ^ "/trace"
+    f "https://%s/api/v4/projects/%d/jobs/%d/trace" gitlab_domain project_id
+      build_id
     |> Uri.of_string
   in
-  let gitlab_header = [("Private-Token", bot_info.gitlab_token)] in
-  let headers = Utils.headers gitlab_header ~bot_info in
+  let open Lwt_result.Infix in
+  gitlab_name_and_token bot_info gitlab_domain
+  |> Lwt.return
+  >>= fun (name, token) ->
+  let gitlab_header = [("Private-Token", token)] in
+  let headers = Utils.headers gitlab_header name in
+  let open Lwt.Infix in
   Client.get ~headers uri
-  >>= fun (_response, body) -> Cohttp_lwt.Body.to_string body
+  >>= fun (_response, body) ->
+  Cohttp_lwt.Body.to_string body |> Lwt.map Result.return
 
-let get_retry_nb ~bot_info ~full_name ~build_id ~build_name =
+let get_retry_nb ~bot_info ~gitlab_domain ~full_name ~build_id ~build_name =
   let open GitLab_GraphQL.GetRetriedJobs in
+  let open Lwt.Infix in
   makeVariables ~fullPath:full_name
     ~jobId:
       (build_id |> f {|"gid://gitlab/Ci::Build/%d"|} |> Yojson.Basic.from_string)
     ()
   |> serializeVariables |> variablesToJson
-  |> send_graphql_query ~bot_info ~query
+  |> send_graphql_query ~bot_info ~gitlab_domain ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= function
   | Ok {project= Some {job= Some {pipeline= Some {jobs= Some {count= 0}}}}} ->

--- a/bot-components/GitLab_queries.mli
+++ b/bot-components/GitLab_queries.mli
@@ -1,8 +1,13 @@
 val get_build_trace :
-  bot_info:Bot_info.t -> project_id:int -> build_id:int -> string Lwt.t
+     bot_info:Bot_info.t
+  -> gitlab_domain:string
+  -> project_id:int
+  -> build_id:int
+  -> (string, string) Lwt_result.t
 
 val get_retry_nb :
      bot_info:Bot_info.t
+  -> gitlab_domain:string
   -> full_name:string
   -> build_id:int
   -> build_name:string

--- a/bot-components/GitLab_subscriptions.ml
+++ b/bot-components/GitLab_subscriptions.ml
@@ -32,7 +32,9 @@ let job_info_of_json json =
   let project_id = json |> member "project_id" |> to_int in
   let base_commit, head_commit = json |> extract_commit in
   let branch = json |> member "ref" |> to_string in
-  let repo_url = json |> member "repository" |> member "url" |> to_string in
+  let http_repo_url =
+    json |> member "repository" |> member "homepage" |> to_string
+  in
   let stage = json |> member "build_stage" |> to_string in
   let failure_reason =
     json |> member "build_failure_reason" |> to_string |> Option.some
@@ -44,7 +46,8 @@ let job_info_of_json json =
   ; stage
   ; failure_reason
   ; allow_fail
-  ; common_info= {base_commit; head_commit; branch; repo_url; project_id} }
+  ; common_info= {base_commit; head_commit; branch; http_repo_url; project_id}
+  }
 
 (* For use to decode builds inside a pipeline webhook *)
 let build_info_of_json json =
@@ -70,8 +73,7 @@ let pipeline_info_of_json json =
   let base_commit, head_commit = json |> extract_commit in
   let branch = pipeline_json |> member "ref" |> to_string in
   let project = json |> member "project" in
-  let repo_url = project |> member "web_url" |> to_string in
-  let project_path = project |> member "path_with_namespace" |> to_string in
+  let http_repo_url = project |> member "web_url" |> to_string in
   let project_id = project |> member "id" |> to_int in
   let variables =
     pipeline_json |> member "variables" |> to_list
@@ -88,8 +90,7 @@ let pipeline_info_of_json json =
   in
   { state
   ; pipeline_id
-  ; project_path
-  ; common_info= {head_commit; base_commit; branch; repo_url; project_id}
+  ; common_info= {head_commit; base_commit; branch; http_repo_url; project_id}
   ; variables
   ; stages
   ; builds }

--- a/bot-components/GitLab_types.mli
+++ b/bot-components/GitLab_types.mli
@@ -2,7 +2,7 @@ type ci_common_info =
   { head_commit: string
   ; base_commit: string option
   ; branch: string
-  ; repo_url: string
+  ; http_repo_url: string
   ; project_id: int }
 
 type 'a job_info =
@@ -17,7 +17,6 @@ type 'a job_info =
 type pipeline_info =
   { state: string
   ; pipeline_id: int
-  ; project_path: string
   ; common_info: ci_common_info
   ; variables: (string * string) list
   ; stages: string list

--- a/bot-components/GraphQL_query.mli
+++ b/bot-components/GraphQL_query.mli
@@ -1,7 +1,9 @@
+type api = GitHub | GitLab of string
+
 val send_graphql_query :
      bot_info:Bot_info.t
   -> ?extra_headers:(string * string) list
-  -> api:[`GitHub | `GitLab]
+  -> api:api
   -> query:string
   -> parse:(Yojson.Basic.t -> 'a)
   -> Yojson.Basic.t

--- a/bot-components/Utils.mli
+++ b/bot-components/Utils.mli
@@ -2,15 +2,15 @@ val f : ('a, unit, string) format -> 'a
 
 val string_match : regexp:string -> string -> bool
 
-val headers : bot_info:Bot_info.t -> (string * string) list -> Cohttp.Header.t
+val headers : (string * string) list -> string -> Cohttp.Header.t
 
 val print_response : Cohttp.Response.t * Cohttp_lwt.Body.t -> unit Lwt.t
 
 val send_request :
-     bot_info:Bot_info.t
-  -> body:Cohttp_lwt.Body.t
+     body:Cohttp_lwt.Body.t
   -> uri:Uri.t
   -> (string * string) list
+  -> string
   -> unit Lwt.t
 
 val project_api_preview_header : (string * string) list

--- a/coq_bug_minimizer.sh
+++ b/coq_bug_minimizer.sh
@@ -2,7 +2,7 @@
 
 # usage: coq_bug_minimizer.sh 'script' comment_thread_id comment_author github_token bot_name bot_domain owner repo coq_version ocaml_version minimizer_extra_arguments
 
-set -ex
+set -e
 
 if [ $# != 11 ]; then >&2 echo Bad argument count; exit 1; fi
 

--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -30,7 +30,6 @@ app_id="31373"
   [mappings.math-comp]
   github="math-comp/math-comp"
   gitlab="math-comp/math-comp"
-  gitlab_domain="gitlab.inria.fr"
 
   [mappings.docker-mathcomp]
   github="math-comp/docker-mathcomp"

--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -8,6 +8,16 @@ domain="coqbot.herokuapp.com"
 [github]
 app_id="31373"
 
+[gitlab]
+  [gitlab.com]
+  domain="gitlab.com"
+  api_token_env_var="GITLAB_ACCESS_TOKEN"
+
+  [gitlab.inria]
+  domain="gitlab.inria.fr"
+  api_token_env_var="INRIA_GITLAB_ACCESS_TOKEN"
+  bot_name="x-CBot"
+
 [mappings]
   [mappings.coq]
   github="coq/coq"
@@ -16,3 +26,13 @@ app_id="31373"
   [mappings.opam-coq-archive]
   github="coq/opam-coq-archive"
   gitlab="coq/opam-coq-archive"
+
+  [mappings.math-comp]
+  github="math-comp/math-comp"
+  gitlab="math-comp/math-comp"
+  gitlab_domain="gitlab.inria.fr"
+
+  [mappings.docker-mathcomp]
+  github="math-comp/docker-mathcomp"
+  gitlab="math-comp/docker-mathcomp"
+  gitlab_domain="gitlab.inria.fr"

--- a/make_ancestor.sh
+++ b/make_ancestor.sh
@@ -27,7 +27,7 @@ wtree=$(mktemp -d)
   # of $base merge will do nothing even with --no-ff.
   # We assume $base is never ahead of $head.
   git reset --hard "$basecommit"
-  if ! git merge --no-ff "$headcommit" \
+  if ! git merge --no-stat --no-ff "$headcommit" \
        -m "[CI merge] PR #$prnum: $pr_title" \
        -m "Bot merge $basecommit and $headcommit";
   then

--- a/run_ci_minimization.sh
+++ b/run_ci_minimization.sh
@@ -2,7 +2,7 @@
 
 # usage: coq_bug_minimizer.sh comment_thread_id github_token bot_name bot_domain owner repo pr_number docker_image target opam_switch failing_urls passing_urls base head minimizer_extra_arguments [bug_file]
 
-set -ex
+set -e
 
 if [ $# != 15 ] && [ $# != 16 ]; then >&2 echo Bad argument count; exit 1; fi
 

--- a/src/actions.ml
+++ b/src/actions.ml
@@ -2289,6 +2289,30 @@ let remove_labels_if_present ~bot_info (issue : issue_info) labels =
     |> add_remove_labels ~bot_info ~add:false issue )
   |> Lwt.async
 
+(* TODO: ensure there's no race condition for 2 push with very close timestamps *)
+let mirror_action ~bot_info ?(force = true) ~owner ~repo ~base_ref ~head_sha ()
+    =
+  (let open Lwt_result.Infix in
+  let local_ref = head_sha in
+  let gh_ref =
+    {repo_url= f "https://github.com/%s/%s" owner repo; name= base_ref}
+  in
+  (* TODO: generalize to case where mapping is not one-to-one *)
+  let gl_ref =
+    { repo_url= gitlab_repo ~bot_info ~gitlab_full_name:(owner ^ "/" ^ repo)
+    ; name= base_ref }
+  in
+  git_fetch gh_ref local_ref |> execute_cmd
+  >>= fun () -> git_push ~force ~remote_ref:gl_ref ~local_ref () |> execute_cmd
+  )
+  >>= function
+  | Ok () ->
+      Lwt.return_unit
+  | Error e ->
+      Lwt_io.printlf "Error while mirroring branch %s of repository %s/%s: %s"
+        base_ref owner repo e
+
+(* TODO: ensure there's no race condition for 2 push with very close timestamps *)
 let update_pr ?full_ci ?(skip_author_check = false) ~bot_info
     (pr_info : issue_info pull_request_info) ~gitlab_mapping ~github_mapping =
   let open Lwt_result.Infix in
@@ -2599,7 +2623,7 @@ let project_action ~bot_info ~(issue : issue) ~column_id =
   | _ ->
       Lwt_io.printf "This was not a request inclusion column: ignoring.\n"
 
-let push_action ~bot_info ~base_ref ~commits_msg =
+let coq_push_action ~bot_info ~base_ref ~commits_msg =
   Stdio.printf "Merge and backport commit messages:\n" ;
   let commit_action commit_msg =
     if string_match ~regexp:"^Merge PR #\\([0-9]*\\):" commit_msg then

--- a/src/actions.mli
+++ b/src/actions.mli
@@ -48,7 +48,7 @@ val run_ci_action :
   -> comment_info:GitHub_types.comment_info
   -> ?full_ci:bool
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
-  -> github_mapping:(string, string) Base.Hashtbl.t
+  -> github_mapping:(string, string * string) Base.Hashtbl.t
   -> unit
   -> (Cohttp.Response.t * Cohttp_lwt__Body.t) Lwt.t
 
@@ -56,7 +56,7 @@ val pull_request_closed_action :
      bot_info:Bot_info.t
   -> GitHub_types.issue_info GitHub_types.pull_request_info
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
-  -> github_mapping:(string, string) Base.Hashtbl.t
+  -> github_mapping:(string, string * string) Base.Hashtbl.t
   -> unit Lwt.t
 
 val pull_request_updated_action :
@@ -64,7 +64,7 @@ val pull_request_updated_action :
   -> action:GitHub_types.pull_request_action
   -> pr_info:GitHub_types.issue_info GitHub_types.pull_request_info
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
-  -> github_mapping:(string, string) Base.Hashtbl.t
+  -> github_mapping:(string, string * string) Base.Hashtbl.t
   -> (Cohttp.Response.t * Cohttp_lwt__.Body.t) Lwt.t
 
 val adjust_milestone :
@@ -85,6 +85,7 @@ val coq_push_action :
 val mirror_action :
      bot_info:Bot_info.t
   -> ?force:bool
+  -> gitlab_domain:string
   -> owner:string
   -> repo:string
   -> base_ref:string

--- a/src/actions.mli
+++ b/src/actions.mli
@@ -76,10 +76,20 @@ val adjust_milestone :
 val project_action :
   bot_info:Bot_info.t -> issue:GitHub_types.issue -> column_id:int -> unit Lwt.t
 
-val push_action :
+val coq_push_action :
      bot_info:Bot_info.t
   -> base_ref:string
   -> commits_msg:string list
+  -> unit Lwt.t
+
+val mirror_action :
+     bot_info:Bot_info.t
+  -> ?force:bool
+  -> owner:string
+  -> repo:string
+  -> base_ref:string
+  -> head_sha:string
+  -> unit
   -> unit Lwt.t
 
 val ci_minimize :

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -192,7 +192,7 @@ let callback _conn req body =
             ~body:(f "Unsupported event %s." e)
             ()
       | Error ("Webhook password mismatch." as e) ->
-          Stdio.print_string e ;
+          (fun () -> Lwt_io.printl e) |> Lwt.async ;
           Server.respond_string ~status:(Code.status_of_code 401)
             ~body:(f "Error: %s" e) ()
       | Error e ->
@@ -514,7 +514,7 @@ let callback _conn req body =
           Server.respond_string ~status:`OK
             ~body:"No action taken: event or action is not yet supported." ()
       | Error ("Webhook signed but with wrong signature." as e) ->
-          Stdio.print_string e ;
+          (fun () -> Lwt_io.printl e) |> Lwt.async ;
           Server.respond_string ~status:(Code.status_of_code 401)
             ~body:(f "Error: %s" e) ()
       | Error e ->

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -238,7 +238,7 @@ let callback _conn req body =
                     branch on GitLab."
                    owner repo )
               ()
-        | "math-comp", ("docker-mathcomp" | "math-comp") ->
+        | "math-comp", "docker-mathcomp" (* | "math-comp" *) ->
             (fun () ->
               init_git_bare_repository ~bot_info
               >>= fun () ->

--- a/src/config.ml
+++ b/src/config.ml
@@ -117,22 +117,17 @@ let bot_email toml_data =
 let github_app_id toml_data =
   match subkey_value toml_data "github" "app_id" with
   | None ->
-      let id = Sys.getenv_exn "GITHUB_APP_ID" |> Int.of_string in
-      Stdio.printf "Found github app id: %d\n" id ;
-      id
+      Sys.getenv_exn "GITHUB_APP_ID" |> Int.of_string
   | Some app_id ->
       app_id |> Int.of_string
 
 let github_private_key () =
   (*string_of_file_path "./github.private-key.pem"*)
   match
-    let private_k = Sys.getenv_exn "GITHUB_PRIVATE_KEY" in
-    Stdio.printf "Found private key: %s\n" private_k ;
-    private_k |> Cstruct.of_string |> X509.Private_key.decode_pem
+    Sys.getenv_exn "GITHUB_PRIVATE_KEY"
+    |> Cstruct.of_string |> X509.Private_key.decode_pem
   with
   | Ok (`RSA priv) ->
-      Stdio.printf "Private key bit size: %d\n"
-        (Mirage_crypto_pk.Rsa.priv_bits priv) ;
       priv
   | Ok _ ->
       failwith "Not an RSA key"

--- a/src/config.ml
+++ b/src/config.ml
@@ -25,12 +25,50 @@ let port toml_data =
     ~default:
       (Option.value_map (Sys.getenv "PORT") ~f:Int.of_string ~default:8000)
 
-let gitlab_access_token toml_data =
-  match subkey_value toml_data "gitlab" "api_token" with
-  | None ->
-      Sys.getenv_exn "GITLAB_ACCESS_TOKEN"
-  | Some secret ->
-      secret
+let github_bot_name toml_data =
+  Option.value_map
+    (subkey_value toml_data "bot" "name")
+    ~f:String.of_string ~default:"coqbot"
+
+let gitlab_instances toml_data =
+  ( try
+      match find "gitlab" toml_data with
+      | Toml.Types.TTable a ->
+          list_table_keys a
+          |> List.map ~f:(fun k ->
+                 let bot_name =
+                   subkey_value a k "bot_name"
+                   |> Option.value ~default:(github_bot_name toml_data)
+                 in
+                 match
+                   (subkey_value a k "domain", subkey_value a k "api_token")
+                 with
+                 | None, _ ->
+                     failwith
+                       (f "Invalid gitlab.%s configuration: missing domain key."
+                          k )
+                 | Some domain, Some api_token ->
+                     (* If api_token is found, we use its value in priority *)
+                     (domain, (bot_name, api_token))
+                 | Some domain, None -> (
+                   (* Otherwise, we look for an environment variable, whose
+                      name is given by api_token_env_var *)
+                   match subkey_value a k "api_token_env_var" with
+                   | Some api_token_env_var ->
+                       (domain, (bot_name, Sys.getenv_exn api_token_env_var))
+                   | _ ->
+                       failwith
+                         (f
+                            "Invalid gitlab.%s configuration: missing \
+                             api_token and api_token_env_var keys."
+                            k ) ) )
+      | _ ->
+          failwith "Invalid gitlab configuration: not a table."
+    with Stdlib.Not_found ->
+      [ ( "gitlab.com"
+        , (github_bot_name toml_data, Sys.getenv_exn "GITLAB_ACCESS_TOKEN") ) ]
+  )
+  |> Hashtbl.of_alist_exn (module String)
 
 let github_access_token toml_data =
   match subkey_value toml_data "github" "api_token" with
@@ -64,22 +102,17 @@ let daily_schedule_secret toml_data =
   | Some secret ->
       secret
 
-let bot_name toml_data =
-  Option.value_map
-    (subkey_value toml_data "bot" "name")
-    ~f:String.of_string ~default:"coqbot"
-
 let bot_domain toml_data =
   Option.value_map
     (subkey_value toml_data "server" "domain")
     ~f:String.of_string
-    ~default:(f "%s.herokuapp.com" (bot_name toml_data))
+    ~default:(f "%s.herokuapp.com" (github_bot_name toml_data))
 
 let bot_email toml_data =
   Option.value_map
     (subkey_value toml_data "bot" "email")
     ~f:String.of_string
-    ~default:(f "%s@users.noreply.github.com" (bot_name toml_data))
+    ~default:(f "%s@users.noreply.github.com" (github_bot_name toml_data))
 
 let github_app_id toml_data =
   match subkey_value toml_data "github" "app_id" with
@@ -89,8 +122,6 @@ let github_app_id toml_data =
       id
   | Some app_id ->
       app_id |> Int.of_string
-
-(*let string_of_file_path path = Stdio.In_channel.(with_file path ~f:input_all)*)
 
 let github_private_key () =
   (*string_of_file_path "./github.private-key.pem"*)
@@ -109,21 +140,24 @@ let github_private_key () =
       failwith (f "Error while decoding RSA key: %s" e)
 
 let parse_mappings mappings =
-  let keys = list_table_keys mappings in
   let assoc =
-    List.(
-      fold_left
-        ~f:(fun assoc_table k ->
-          (subkey_value mappings k "github", subkey_value mappings k "gitlab")
-          :: assoc_table )
-        ~init:[] keys
-      |> filter_map ~f:(function
+    list_table_keys mappings
+    |> List.map ~f:(fun k ->
+           match
+             (subkey_value mappings k "github", subkey_value mappings k "gitlab")
+           with
            | Some gh, Some gl ->
-               Some (gh, gl)
+               let gl_domain =
+                 subkey_value mappings k "gitlab_domain"
+                 |> Option.value ~default:"gitlab.com"
+               in
+               (gh, (gl_domain, gl))
            | _, _ ->
-               None ) )
+               failwith (f "Missing github or gitlab key for mappings.%s" k) )
   in
-  let assoc_rev = List.map assoc ~f:(fun (gh, gl) -> (gl, gh)) in
+  let assoc_rev =
+    List.map assoc ~f:(fun (gh, (gl_domain, gl)) -> (gl_domain ^ "/" ^ gl, gh))
+  in
   let get_table t =
     match t with
     | `Duplicate_key _ ->

--- a/src/config.mli
+++ b/src/config.mli
@@ -8,26 +8,27 @@ val string_of_mapping : (string, string) Base.Hashtbl.t -> string
 
 val port : Toml.Types.table -> int
 
-val gitlab_access_token : Toml.Types.table -> string
-
-val github_access_token : Toml.Types.table -> string
-
-val github_webhook_secret : Toml.Types.table -> string
+val gitlab_instances :
+  Toml.Types.table -> (string, string * string) Base.Hashtbl.t
 
 val gitlab_webhook_secret : Toml.Types.table -> string
 
 val daily_schedule_secret : Toml.Types.table -> string
 
-val bot_name : Toml.Types.table -> string
-
 val bot_domain : Toml.Types.table -> string
 
 val bot_email : Toml.Types.table -> string
 
+val github_bot_name : Toml.Types.table -> string
+
+val github_access_token : Toml.Types.table -> string
+
 val github_app_id : Toml.Types.table -> int
+
+val github_webhook_secret : Toml.Types.table -> string
 
 val github_private_key : unit -> Mirage_crypto_pk.Rsa.priv
 
 val make_mappings_table :
      Toml.Types.value Toml.Types.Table.t
-  -> (string, string) Base.Hashtbl.t * (string, string) Base.Hashtbl.t
+  -> (string, string * string) Base.Hashtbl.t * (string, string) Base.Hashtbl.t

--- a/src/git_utils.ml
+++ b/src/git_utils.ml
@@ -57,7 +57,7 @@ let gitlab_ref ~bot_info ~(issue : issue) ~github_mapping ~gitlab_mapping =
   | Some r ->
       Lwt.return r )
   >|= fun gitlab_full_name ->
-  { name= f "pr-%d" issue.number
+  { name= f "refs/heads/pr-%d" issue.number
   ; repo_url= gitlab_repo ~gitlab_full_name ~bot_info }
 
 let ( |&& ) command1 command2 = command1 ^ " && " ^ command2
@@ -83,7 +83,7 @@ let git_fetch ?(force = true) remote_ref local_branch_name =
     (Stdlib.Filename.quote local_branch_name)
 
 let git_push ?(force = true) ?(options = "") ~remote_ref ~local_ref () =
-  f "git push %s %s%s:refs/heads/%s %s" remote_ref.repo_url
+  f "git push %s %s%s:%s %s" remote_ref.repo_url
     (if force then " +" else " ")
     (Stdlib.Filename.quote local_ref)
     (Stdlib.Filename.quote remote_ref.name)

--- a/src/git_utils.ml
+++ b/src/git_utils.ml
@@ -4,6 +4,7 @@ open Bot_components.Bot_info
 open Bot_components.GitHub_types
 open Helpers
 open Lwt.Infix
+open Lwt.Syntax
 
 let gitlab_repo ~bot_info ~gitlab_domain ~gitlab_full_name =
   gitlab_token bot_info gitlab_domain
@@ -194,13 +195,13 @@ let git_run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo ~pr_number
   |> execute_cmd
 
 let init_git_bare_repository ~bot_info =
-  Stdio.printf "Initializing repository...\n" ;
+  let* () = Lwt_io.printl "Initializing repository..." in
   "git init --bare"
   |&& f {|git config user.email "%s"|} bot_info.email
   |&& f {|git config user.name "%s"|} bot_info.github_name
   |> execute_cmd
-  >|= function
+  >>= function
   | Ok _ ->
-      Stdio.printf "Bare repository initialized.\n"
+      Lwt_io.printl "Bare repository initialized."
   | Error e ->
-      Stdio.printf "%s.\n" e
+      Lwt_io.printlf "Error while initializing bare repository: %s." e

--- a/src/git_utils.ml
+++ b/src/git_utils.ml
@@ -96,7 +96,7 @@ let execute_cmd command =
       report_status command "was stopped by signal number" signal
 
 let git_fetch ?(force = true) remote_ref local_branch_name =
-  f "git fetch -fu %s %s%s:refs/heads/%s" remote_ref.repo_url
+  f "git fetch --quiet -fu %s %s%s:refs/heads/%s" remote_ref.repo_url
     (if force then "+" else "")
     (Stdlib.Filename.quote remote_ref.name)
     (Stdlib.Filename.quote local_branch_name)

--- a/src/git_utils.mli
+++ b/src/git_utils.mli
@@ -1,3 +1,6 @@
+val gitlab_repo :
+  bot_info:Bot_components.Bot_info.t -> gitlab_full_name:string -> string
+
 val gitlab_ref :
      bot_info:Bot_components.Bot_info.t
   -> issue:Bot_components.GitHub_types.issue

--- a/src/git_utils.mli
+++ b/src/git_utils.mli
@@ -1,12 +1,15 @@
 val gitlab_repo :
-  bot_info:Bot_components.Bot_info.t -> gitlab_full_name:string -> string
+     bot_info:Bot_components.Bot_info.t
+  -> gitlab_domain:string
+  -> gitlab_full_name:string
+  -> (string, string) Result.t
 
 val gitlab_ref :
      bot_info:Bot_components.Bot_info.t
   -> issue:Bot_components.GitHub_types.issue
-  -> github_mapping:(string, string) Base.Hashtbl.t
+  -> github_mapping:(string, string * string) Base.Hashtbl.t
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
-  -> Bot_components.GitHub_types.remote_ref_info Lwt.t
+  -> (Bot_components.GitHub_types.remote_ref_info, string) Lwt_result.t
 
 val ( |&& ) : string -> string -> string
 

--- a/src/helpers.mli
+++ b/src/helpers.mli
@@ -21,7 +21,14 @@ val remove_between : string -> int -> int -> string
 val trim_comments : string -> string
 
 val github_repo_of_gitlab_project_path :
-  gitlab_mapping:(string, string) Base.Hashtbl.t -> string -> string * string
+     gitlab_mapping:(string, string) Base.Hashtbl.t
+  -> gitlab_domain:string
+  -> gitlab_repo_full_name:string
+  -> string * string
+
+val parse_gitlab_repo_url : http_repo_url:string -> string * string
 
 val github_repo_of_gitlab_url :
-  gitlab_mapping:(string, string) Base.Hashtbl.t -> string -> string * string
+     gitlab_mapping:(string, string) Base.Hashtbl.t
+  -> http_repo_url:string
+  -> string * string

--- a/src/helpers.mli
+++ b/src/helpers.mli
@@ -26,9 +26,10 @@ val github_repo_of_gitlab_project_path :
   -> gitlab_repo_full_name:string
   -> string * string
 
-val parse_gitlab_repo_url : http_repo_url:string -> string * string
+val parse_gitlab_repo_url :
+  http_repo_url:string -> (string * string, string) result
 
 val github_repo_of_gitlab_url :
      gitlab_mapping:(string, string) Base.Hashtbl.t
   -> http_repo_url:string
-  -> string * string
+  -> (string * string, string) result


### PR DESCRIPTION
This is the result of work with @erikmd over the last month or so.

The first commit has been tested and adds support for mirroring a hard-coded selection of GitHub repositories to GitLab (we plan to make the feature more largely available through configuration files, which would complete #234, see the message for the first commit).

The second commit has not been tested yet and adds support for multiple GitLab instances. It requires supporting multiple bot names as not all GitLab instances will allow creating a new user with the same username. (The name of the bot on gitlab.inria.fr will be `x-CBot`).