### PR TITLE
Strip out more ANSI color codes

### DIFF
--- a/src/actions.ml
+++ b/src/actions.ml
@@ -25,7 +25,7 @@ let send_status_check ~bot_info job_info ~pr_num (gh_owner, gh_repo)
   in
   let trace_lines =
     trace
-    |> Str.global_replace (Str.regexp "\027\\[[0-9]*;[0-9]*m") ""
+    |> Str.global_replace (Str.regexp "\027\\[[0-9;]*m") ""
     |> Str.global_replace (Str.regexp "\027\\[0K") ""
     |> Str.global_replace (Str.regexp "section_start:[0-9]*:[a-z_]*\r") ""
     |> Str.global_replace (Str.regexp "section_end:[0-9]*:[a-z_]*\r") ""


### PR DESCRIPTION
This should issues like
https://github.com/coq/coq/pull/18446/checks?check_run_id=20043646334 not finding `Error` since the introduction of colors in https://github.com/coq/coq/pull/18338.  ANSI color codes sometimes include three numeric components.  If we want to be more precise, we could use `([0-9]+;?){1,3}` or even `([0-9]+;){0,2}[0-9]+`, but I think this might be overkill, and there's not too much harm in using the simpler expression.