### PR TITLE
Simplify Docker image build.

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -17,7 +17,6 @@ RUN opam install . --destdir /src/opam-install
 
 # Store the dynamic dependencies of the server
 RUN opam depext -ln coq-bot > /src/depexts-coq-bot
-RUN opam depext -ln bot-components > /src/depexts-bot-components
 
 
 FROM alpine:3.10 AS app
@@ -33,11 +32,9 @@ RUN apk update \
   && adduser coqbot -DG coqbot
 
 COPY --from=builder /src/depexts-coq-bot depexts-coq-bot
-COPY --from=builder /src/depexts-bot-components depexts-bot-components
 
 # Install the required dynamic dependencies
 RUN cat depexts-coq-bot | xargs apk --update add
-RUN cat depexts-bot-components | xargs apk --update add
 
 EXPOSE 8000
 


### PR DESCRIPTION
In principle, the second command is not needed since coq-bot already depends on bot-components. Furthermore, since a few days, this second command seems to consistently trigger a timeout in our CI during the Docker build. So removing it could help fix this issue.