### PR TITLE
Bump OCaml version used in Docker image.

### DIFF
--- a/bot-components.opam
+++ b/bot-components.opam
@@ -13,7 +13,7 @@ depends: [
   "cohttp-lwt" {>= "2.5.4"}
   "cohttp-lwt-unix" {>= "2.5.4"}
   "lwt_ssl" {>= "1.1.3"}
-  "ssl" {= "0.5.9"}
+  "ssl" {>= "0.5.9"}
   "stdio" {>= "v0.14.0"}
   "ohex" {>= "0.2.0"}
   "mirage-crypto" {>= "1.0.0"}

--- a/coq-bot.opam
+++ b/coq-bot.opam
@@ -7,7 +7,6 @@ license: "MIT"
 homepage: "https://github.com/coq/bot"
 bug-reports: "https://github.com/coq/bot/issues"
 depends: [
-  "ocaml" {>= "4.10"}
   "dune" {>= "2.2"}
   "base" {>= "v0.14.0"}
   "lwt" {>= "5.6.0"}

--- a/dune-project
+++ b/dune-project
@@ -12,7 +12,6 @@
  (name coq-bot)
  (synopsis "A (Coq Development Team) bot written in OCaml")
  (depends
-  (ocaml (>= 4.10))
   (dune (>= 2.2))
   (base (>= v0.14.0))
   (lwt (>= 5.6.0))

--- a/dune-project
+++ b/dune-project
@@ -39,7 +39,7 @@
   (cohttp-lwt (>= 2.5.4))
   (cohttp-lwt-unix (>= 2.5.4))
   (lwt_ssl (>= 1.1.3))
-  (ssl (= 0.5.9))
+  (ssl (>= 0.5.9))
   (stdio (>= v0.14.0))
   (ohex (>= 0.2.0))
   (mirage-crypto (>= 1.0.0))

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam2:alpine-3.10-ocaml-4.10 AS builder
+FROM ocaml/opam:alpine-3.20-ocaml-5.2 AS builder
 
 WORKDIR /src
 COPY coq-bot.opam bot-components.opam ./
@@ -6,7 +6,7 @@ COPY coq-bot.opam bot-components.opam ./
 # Install the OCaml libraries needed to compile the program
 RUN echo 'archive-mirrors: [ "https://opam.ocaml.org/cache" ]' >> ~/.opam/config \
   && opam repository set-url default http://opam.ocaml.org \
-  && opam switch 4.10 \
+  && opam switch 5.2 \
   && echo 'pre-session-commands: [ "sudo" "apk" "add" depexts ]' >> ~/.opam/config \
   && OPAMSOLVERTIMEOUT=300 opam install --deps-only .
 
@@ -19,7 +19,7 @@ RUN opam install . --destdir /src/opam-install
 RUN OPAMSOLVERTIMEOUT=300 opam depext -ln coq-bot > /src/depexts-coq-bot
 
 
-FROM alpine:3.10 AS app
+FROM alpine:3.20 AS app
 
 WORKDIR /app
 


### PR DESCRIPTION
This is required since the update of mirage-crypto (#314).

The deployment job was failing because it needed OCaml >= 4.13.

Test deployment in progress: https://github.com/Zimmi48/bot/actions/runs/11554799903