### PR TITLE
Fix dev setup: gitignore, formatting, and schema build rules

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,23 +21,25 @@ ocaml libraries.
 Use the following command to build:
 
 ```
-dune build --ignore-promoted-rules
-```
-
-If you want to update the GraphQL schema:
-
-```
 dune build
 ```
 
-This call to `dune build` without the `--ignore-promoted-rules` option
-requires that a file `bot-components/.github-token` be provided and
-contain a single line with a GitHub API personal token (with no
-specific permission).  It will use this token and the node package
-`get-graphql-schema` to update the GitHub schema stored in
-`bot-component/schema.json`, before building the project.
-Get `get-graphql-schema` with `npm install get-graphql-schema -g` if you're
-not compiling in `nix-shell`.
+Committed GraphQL schemas under `bot-components/github/github-schema.json` and
+`bot-components/gitlab/gitlab-schema.json` are used as-is. Normal builds do not
+re-fetch them.
+
+To refresh the schemas:
+
+```
+dune build @update-schema
+```
+
+Updating the GitHub schema requires `bot-components/.github-token`: one line
+with a GitHub personal access token (no special permission). It uses the
+`get-graphql-schema` npm package. Install with `npm install get-graphql-schema -g` if you are not in `nix-shell`.
+
+After refreshing, rebuild and fix any GraphQL typing breakages, then commit the
+schema JSON and code changes together.
 
 ## Testing locally ##
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests
-        run: nix-shell --run "dune build @tests/runtest --ignore-promoted-rules"
+        run: nix-shell --run "dune build @tests/runtest"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .env
 .direnv
 .envrc
+.bot-env
+*.private-key.pem
+bot.log
 
 # vscode settings
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .bot-env
 *.private-key.pem
 bot.log
+.github-token
 
 # vscode settings
 .vscode

--- a/bot-components/ci/pipeline.ml
+++ b/bot-components/ci/pipeline.ml
@@ -15,19 +15,19 @@ let create_pipeline_summary ?summary_top pipeline_info pipeline_url =
   let sorted_builds =
     pipeline_info.builds
     |> List.sort ~compare:(fun build1 build2 ->
-           String.compare build1.build_name build2.build_name )
+        String.compare build1.build_name build2.build_name )
   in
   let stage_summary =
     pipeline_info.stages
     |> List.concat_map ~f:(fun stage ->
-           sorted_builds
-           |> List.filter_map ~f:(fun build ->
-                  if String.equal build.stage stage then
-                    Some
-                      (f "  - [%s](%s/-/jobs/%d)" build.build_name
-                         pipeline_info.common_info.http_repo_url build.build_id )
-                  else None )
-           |> List.cons ("- " ^ stage) )
+        sorted_builds
+        |> List.filter_map ~f:(fun build ->
+            if String.equal build.stage stage then
+              Some
+                (f "  - [%s](%s/-/jobs/%d)" build.build_name
+                   pipeline_info.common_info.http_repo_url build.build_id )
+            else None )
+        |> List.cons ("- " ^ stage) )
     |> String.concat ~sep:"\n"
   in
   [ f "This [GitLab pipeline](%s) sets the following variables:" pipeline_url

--- a/bot-components/github/GitHub_GitLab_sync.ml
+++ b/bot-components/github/GitHub_GitLab_sync.ml
@@ -9,18 +9,18 @@ let parse_mappings mappings =
   let assoc =
     Utils.list_table_keys mappings
     |> List.map ~f:(fun k ->
-           match
-             ( Utils.subkey_value mappings k "github"
-             , Utils.subkey_value mappings k "gitlab" )
-           with
-           | Some gh, Some gl ->
-               let gl_domain =
-                 Utils.subkey_value mappings k "gitlab_domain"
-                 |> Option.value ~default:"gitlab.com"
-               in
-               (gh, (gl_domain, gl))
-           | _, _ ->
-               failwith (f "Missing github or gitlab key for mappings.%s" k) )
+        match
+          ( Utils.subkey_value mappings k "github"
+          , Utils.subkey_value mappings k "gitlab" )
+        with
+        | Some gh, Some gl ->
+            let gl_domain =
+              Utils.subkey_value mappings k "gitlab_domain"
+              |> Option.value ~default:"gitlab.com"
+            in
+            (gh, (gl_domain, gl))
+        | _, _ ->
+            failwith (f "Missing github or gitlab key for mappings.%s" k) )
   in
   let assoc_rev =
     List.map assoc ~f:(fun (gh, (gl_domain, gl)) -> (gl_domain ^ "/" ^ gl, gh))
@@ -39,7 +39,7 @@ let parse_mappings mappings =
 let gitlab_repo ~bot_info ~gitlab_domain ~gitlab_full_name =
   gitlab_token bot_info gitlab_domain
   |> Result.map ~f:(fun token ->
-         f "https://oauth2:%s@%s/%s.git" token gitlab_domain gitlab_full_name )
+      f "https://oauth2:%s@%s/%s.git" token gitlab_domain gitlab_full_name )
 
 (* Maps a GitLab repository to its corresponding GitHub repository *)
 let github_repo_of_gitlab_project_path ~gitlab_mapping ~gitlab_domain
@@ -67,8 +67,8 @@ let github_repo_of_gitlab_project_path ~gitlab_mapping ~gitlab_domain
 let github_repo_of_gitlab_url ~gitlab_mapping ~http_repo_url =
   Git_utils.parse_gitlab_repo_url ~http_repo_url
   |> Result.map ~f:(fun (gitlab_domain, gitlab_repo_full_name) ->
-         github_repo_of_gitlab_project_path ~gitlab_mapping ~gitlab_domain
-           ~gitlab_repo_full_name )
+      github_repo_of_gitlab_project_path ~gitlab_mapping ~gitlab_domain
+        ~gitlab_repo_full_name )
 
 (* Creates a GitLab remote reference for a GitHub PR to enable triggering GitLab CI/CD pipelines *)
 let gitlab_ci_ref_for_github_pr ~bot_info ~(issue : issue) ~github_mapping
@@ -82,60 +82,60 @@ let gitlab_ci_ref_for_github_pr ~bot_info ~(issue : issue) ~github_mapping
      projects are named the same. *)
   let default_value = (default_gitlab_domain, gh_repo) in
   ( match Hashtbl.find github_mapping gh_repo with
-  | None -> (
-      Stdio.printf "No correspondence found for GitHub repository %s/%s.\n"
-        issue.owner issue.repo ;
-      GitHub_queries.get_default_branch ~bot_info ~owner:issue.owner
-        ~repo:issue.repo
-      >>= function
-      | Ok branch -> (
-          GitHub_queries.get_file_content ~bot_info ~owner:issue.owner
-            ~repo:issue.repo ~branch
-            ~file_name:(f "%s.toml" bot_info.github_name)
-          >>= function
-          | Ok (Some content) ->
-              let gl_domain =
-                Option.value
-                  (Utils.subkey_value
-                     (Utils.toml_of_string content)
-                     "mapping" "gitlab_domain" )
-                  ~default:default_gitlab_domain
-              in
-              let gl_repo =
-                Option.value
-                  (Utils.subkey_value
-                     (Utils.toml_of_string content)
-                     "mapping" "gitlab" )
-                  ~default:gh_repo
-              in
-              ( match
-                  Hashtbl.add gitlab_mapping
-                    ~key:(gl_domain ^ "/" ^ gl_repo)
-                    ~data:gh_repo
-                with
-              | `Duplicate ->
-                  ()
-              | `Ok ->
-                  () ) ;
-              ( match
-                  Hashtbl.add github_mapping ~key:gh_repo
-                    ~data:(gl_domain, gl_repo)
-                with
-              | `Duplicate ->
-                  ()
-              | `Ok ->
-                  () ) ;
-              Lwt.return (gl_domain, gl_repo)
-          | _ ->
-              Lwt.return default_value )
-      | _ ->
-          Lwt.return default_value )
-  | Some r ->
-      Lwt.return r )
+    | None -> (
+        Stdio.printf "No correspondence found for GitHub repository %s/%s.\n"
+          issue.owner issue.repo ;
+        GitHub_queries.get_default_branch ~bot_info ~owner:issue.owner
+          ~repo:issue.repo
+        >>= function
+        | Ok branch -> (
+            GitHub_queries.get_file_content ~bot_info ~owner:issue.owner
+              ~repo:issue.repo ~branch
+              ~file_name:(f "%s.toml" bot_info.github_name)
+            >>= function
+            | Ok (Some content) ->
+                let gl_domain =
+                  Option.value
+                    (Utils.subkey_value
+                       (Utils.toml_of_string content)
+                       "mapping" "gitlab_domain" )
+                    ~default:default_gitlab_domain
+                in
+                let gl_repo =
+                  Option.value
+                    (Utils.subkey_value
+                       (Utils.toml_of_string content)
+                       "mapping" "gitlab" )
+                    ~default:gh_repo
+                in
+                ( match
+                    Hashtbl.add gitlab_mapping
+                      ~key:(gl_domain ^ "/" ^ gl_repo)
+                      ~data:gh_repo
+                  with
+                | `Duplicate ->
+                    ()
+                | `Ok ->
+                    () ) ;
+                ( match
+                    Hashtbl.add github_mapping ~key:gh_repo
+                      ~data:(gl_domain, gl_repo)
+                  with
+                | `Duplicate ->
+                    ()
+                | `Ok ->
+                    () ) ;
+                Lwt.return (gl_domain, gl_repo)
+            | _ ->
+                Lwt.return default_value )
+        | _ ->
+            Lwt.return default_value )
+    | Some r ->
+        Lwt.return r )
   >|= fun (gitlab_domain, gitlab_full_name) ->
   gitlab_repo ~gitlab_domain ~gitlab_full_name ~bot_info
   |> Result.map ~f:(fun gl_repo ->
-         {name= f "refs/heads/pr-%d" issue.number; repo_url= gl_repo} )
+      {name= f "refs/heads/pr-%d" issue.number; repo_url= gl_repo} )
 
 (* TODO: ensure there's no race condition for 2 push with very close timestamps *)
 let mirror_action ~bot_info ?(force = true) ~gitlab_domain ~gh_owner ~gh_repo

--- a/bot-components/github/GitHub_app.ml
+++ b/bot-components/github/GitHub_app.ml
@@ -93,8 +93,8 @@ let get_installations ~bot_info ~key ~app_id =
         Ok
           ( json |> to_list
           |> List.map ~f:(fun json ->
-                 ( json |> member "account" |> member "login" |> to_string
-                 , json |> member "id" |> to_int ) ) )
+              ( json |> member "account" |> member "login" |> to_string
+              , json |> member "id" |> to_int ) ) )
       with
       | Yojson.Json_error err ->
           Error (f "Json error: %s" err)

--- a/bot-components/github/GitHub_automation.ml
+++ b/bot-components/github/GitHub_automation.ml
@@ -19,140 +19,145 @@ let rec merge_pull_request_action ~bot_info ?(t = 1.) comment_info =
           else Some "You are not among the assignees." )
       ; comment_info.issue.labels
         |> List.find ~f:(fun label ->
-               String_utils.string_match ~regexp:"needs:.*" label )
+            String_utils.string_match ~regexp:"needs:.*" label )
         |> Option.map ~f:(fun l -> f "There is still a `%s` label." l)
       ; ( if
             comment_info.issue.labels
             |> List.exists ~f:(fun label ->
-                   String_utils.string_match ~regexp:"kind:.*" label )
+                String_utils.string_match ~regexp:"kind:.*" label )
           then None
           else Some "There is no `kind:` label." )
       ; ( if comment_info.issue.milestoned then None
           else Some "No milestone has been set." ) ]
   in
   ( match reasons_for_not_merging with
-  | _ :: _ ->
-      let bullet_reasons =
-        reasons_for_not_merging |> List.map ~f:(fun x -> "- " ^ x)
-      in
-      let reasons = bullet_reasons |> String.concat ~sep:"\n" in
-      Lwt.return_error
-        (f "@%s: You cannot merge this PR because:\n%s" comment_info.author
-           reasons )
-  | [] -> (
-      GitHub_queries.get_pull_request_reviews_refs ~bot_info
-        ~owner:pr.issue.owner ~repo:pr.issue.repo ~number:pr.issue.number
-      >>= function
-      | Ok reviews_info -> (
-          let comment =
-            List.find reviews_info.last_comments ~f:(fun c ->
-                GitHub_ID.equal comment_info.id c.id )
-          in
-          if (not comment_info.review_comment) && Option.is_none comment then
-            if Float.(t > 5.) then
+    | _ :: _ ->
+        let bullet_reasons =
+          reasons_for_not_merging |> List.map ~f:(fun x -> "- " ^ x)
+        in
+        let reasons = bullet_reasons |> String.concat ~sep:"\n" in
+        Lwt.return_error
+          (f "@%s: You cannot merge this PR because:\n%s" comment_info.author
+             reasons )
+    | [] -> (
+        GitHub_queries.get_pull_request_reviews_refs ~bot_info
+          ~owner:pr.issue.owner ~repo:pr.issue.repo ~number:pr.issue.number
+        >>= function
+        | Ok reviews_info -> (
+            let comment =
+              List.find reviews_info.last_comments ~f:(fun c ->
+                  GitHub_ID.equal comment_info.id c.id )
+            in
+            if (not comment_info.review_comment) && Option.is_none comment then
+              if Float.(t > 5.) then
+                Lwt.return_error
+                  "Something unexpected happened: did not find merge comment \
+                   after retrying three times.\n\
+                   cc @rocq-prover/coqbot-maintainers"
+              else
+                Lwt_unix.sleep t
+                >>= fun () ->
+                merge_pull_request_action ~t:(t *. 2.) ~bot_info comment_info
+                >>= fun () -> Lwt.return_ok ()
+            else if
+              (not comment_info.review_comment)
+              && (Option.value_exn comment).created_by_email
+              (* Option.value_exn doesn't raise an exception because comment isn't None at this point*)
+            then
               Lwt.return_error
-                "Something unexpected happened: did not find merge comment \
-                 after retrying three times.\n\
-                 cc @rocq-prover/coqbot-maintainers"
+                (f
+                   "@%s: Merge requests sent over e-mail are not accepted \
+                    because this puts less guarantee on the authenticity of \
+                    the author of the request."
+                   comment_info.author )
+            else if not (String.equal reviews_info.baseRef "master") then
+              Lwt.return_error
+                (f
+                   "@%s: This PR targets branch `%s` instead of `master`. Only \
+                    release managers can merge in release branches. If you are \
+                    the release manager for this branch, you should use the \
+                    `dev/tools/merge-pr.sh` script to merge this PR. Merging \
+                    with the bot is not supported yet."
+                   comment_info.author reviews_info.baseRef )
             else
-              Lwt_unix.sleep t
-              >>= fun () ->
-              merge_pull_request_action ~t:(t *. 2.) ~bot_info comment_info
-              >>= fun () -> Lwt.return_ok ()
-          else if
-            (not comment_info.review_comment)
-            && (Option.value_exn comment).created_by_email
-            (* Option.value_exn doesn't raise an exception because comment isn't None at this point*)
-          then
+              match reviews_info.review_decision with
+              | NONE | REVIEW_REQUIRED ->
+                  Lwt.return_error
+                    (f
+                       "@%s: You can't merge the PR because it hasn't been \
+                        approved yet."
+                       comment_info.author )
+              | CHANGES_REQUESTED ->
+                  Lwt.return_error
+                    (f
+                       "@%s: You can't merge the PR because some changes are \
+                        requested."
+                       comment_info.author )
+              | APPROVED -> (
+                  GitHub_queries.get_team_membership ~bot_info
+                    ~org:"rocq-prover" ~team:"pushers" ~user:comment_info.author
+                  >>= function
+                  | Ok false ->
+                      (* User not found in the team *)
+                      Lwt.return_error
+                        (f
+                           "@%s: You can't merge this PR because you're not a \
+                            member of the `@rocq-prover/pushers` team. Look at \
+                            the contributing guide for how to join this team."
+                           comment_info.author )
+                  | Ok true -> (
+                      GitHub_mutations.merge_pull_request ~bot_info ~pr_id:pr.id
+                        ~commit_headline:
+                          (f "Merge PR #%d: %s" pr.issue.number
+                             comment_info.issue.title )
+                        ~commit_body:
+                          ( List.fold_left reviews_info.approved_reviews ~init:""
+                              ~f:(fun s r -> s ^ f "Reviewed-by: %s\n" r )
+                          ^ List.fold_left reviews_info.comment_reviews ~init:""
+                              ~f:(fun s r -> s ^ f "Ack-by: %s\n" r )
+                          ^ f
+                              "Co-authored-by: %s <%s@users.noreply.github.com>\n"
+                              comment_info.author comment_info.author )
+                        ~merge_method:MERGE ()
+                      >>= fun () ->
+                      match
+                        List.fold_left ~init:[] reviews_info.files
+                          ~f:(fun acc f ->
+                            if
+                              String_utils.string_match
+                                ~regexp:"dev/ci/user-overlays/\\(.*\\)" f
+                            then
+                              let f = Str.matched_group 1 f in
+                              if String.equal f "README.md" then acc
+                              else f :: acc
+                            else acc )
+                      with
+                      | [] ->
+                          Lwt.return_ok ()
+                      | overlays ->
+                          GitHub_mutations.post_comment ~bot_info ~id:pr.id
+                            ~message:
+                              (f
+                                 "@%s: Please take care of the following \
+                                  overlays:\n\
+                                  %s"
+                                 comment_info.author
+                                 (List.fold_left overlays ~init:""
+                                    ~f:(fun s o -> s ^ f "- %s\n" o ) ) )
+                          >>= Utils.report_on_posting_comment
+                          >>= fun () -> Lwt.return_ok () )
+                  | Error e ->
+                      Lwt.return_error
+                        (f
+                           "Something unexpected happened: %s\n\
+                            cc @rocq-prover/coqbot-maintainers"
+                           e ) ) )
+        | Error e ->
             Lwt.return_error
               (f
-                 "@%s: Merge requests sent over e-mail are not accepted \
-                  because this puts less guarantee on the authenticity of the \
-                  author of the request."
-                 comment_info.author )
-          else if not (String.equal reviews_info.baseRef "master") then
-            Lwt.return_error
-              (f
-                 "@%s: This PR targets branch `%s` instead of `master`. Only \
-                  release managers can merge in release branches. If you are \
-                  the release manager for this branch, you should use the \
-                  `dev/tools/merge-pr.sh` script to merge this PR. Merging \
-                  with the bot is not supported yet."
-                 comment_info.author reviews_info.baseRef )
-          else
-            match reviews_info.review_decision with
-            | NONE | REVIEW_REQUIRED ->
-                Lwt.return_error
-                  (f
-                     "@%s: You can't merge the PR because it hasn't been \
-                      approved yet."
-                     comment_info.author )
-            | CHANGES_REQUESTED ->
-                Lwt.return_error
-                  (f
-                     "@%s: You can't merge the PR because some changes are \
-                      requested."
-                     comment_info.author )
-            | APPROVED -> (
-                GitHub_queries.get_team_membership ~bot_info ~org:"rocq-prover"
-                  ~team:"pushers" ~user:comment_info.author
-                >>= function
-                | Ok false ->
-                    (* User not found in the team *)
-                    Lwt.return_error
-                      (f
-                         "@%s: You can't merge this PR because you're not a \
-                          member of the `@rocq-prover/pushers` team. Look at \
-                          the contributing guide for how to join this team."
-                         comment_info.author )
-                | Ok true -> (
-                    GitHub_mutations.merge_pull_request ~bot_info ~pr_id:pr.id
-                      ~commit_headline:
-                        (f "Merge PR #%d: %s" pr.issue.number
-                           comment_info.issue.title )
-                      ~commit_body:
-                        ( List.fold_left reviews_info.approved_reviews ~init:""
-                            ~f:(fun s r -> s ^ f "Reviewed-by: %s\n" r )
-                        ^ List.fold_left reviews_info.comment_reviews ~init:""
-                            ~f:(fun s r -> s ^ f "Ack-by: %s\n" r )
-                        ^ f "Co-authored-by: %s <%s@users.noreply.github.com>\n"
-                            comment_info.author comment_info.author )
-                      ~merge_method:MERGE ()
-                    >>= fun () ->
-                    match
-                      List.fold_left ~init:[] reviews_info.files
-                        ~f:(fun acc f ->
-                          if
-                            String_utils.string_match
-                              ~regexp:"dev/ci/user-overlays/\\(.*\\)" f
-                          then
-                            let f = Str.matched_group 1 f in
-                            if String.equal f "README.md" then acc else f :: acc
-                          else acc )
-                    with
-                    | [] ->
-                        Lwt.return_ok ()
-                    | overlays ->
-                        GitHub_mutations.post_comment ~bot_info ~id:pr.id
-                          ~message:
-                            (f
-                               "@%s: Please take care of the following overlays:\n\
-                                %s"
-                               comment_info.author
-                               (List.fold_left overlays ~init:"" ~f:(fun s o ->
-                                    s ^ f "- %s\n" o ) ) )
-                        >>= Utils.report_on_posting_comment
-                        >>= fun () -> Lwt.return_ok () )
-                | Error e ->
-                    Lwt.return_error
-                      (f
-                         "Something unexpected happened: %s\n\
-                          cc @rocq-prover/coqbot-maintainers" e ) ) )
-      | Error e ->
-          Lwt.return_error
-            (f
-               "Something unexpected happened: %s\n\
-                cc @rocq-prover/coqbot-maintainers" e ) ) )
+                 "Something unexpected happened: %s\n\
+                  cc @rocq-prover/coqbot-maintainers"
+                 e ) ) )
   >>= function
   | Ok () ->
       Lwt.return_unit
@@ -254,49 +259,51 @@ let add_to_column ~bot_info ~backport_to id option =
     ~project:11 ~field ~options:[|option|]
   >>= fun project_info ->
   ( match project_info with
-  | Ok (project_id, Some (field_id, [(option', field_value_id)]))
-    when String.equal option option' ->
-      Lwt.return_ok (project_id, field_id, field_value_id)
-  | Ok (_, Some (_, [])) ->
-      Lwt.return_error
-        (f "Error: Could not find '%s' option in the field." option)
-  | Ok (_, Some _) ->
-      Lwt.return_error
-        (f "Error: Unexpected result when looking for '%s'." option)
-  | Ok (project_id, None) -> (
-      Lwt_io.printlf
-        "Required backporting field '%s' does not exist yet. Creating it..."
-        field
-      >>= fun () ->
-      GitHub_mutations.create_new_release_management_field ~bot_info ~project_id
-        ~field
-      >>= function
-      | Ok (field_id, options) -> (
-        match
-          List.find_map options ~f:(fun (option', field_value_id) ->
-              if String.equal option option' then Some field_value_id else None )
-        with
-        | Some field_value_id ->
-            Lwt.return_ok (project_id, field_id, field_value_id)
-        | None ->
+    | Ok (project_id, Some (field_id, [(option', field_value_id)]))
+      when String.equal option option' ->
+        Lwt.return_ok (project_id, field_id, field_value_id)
+    | Ok (_, Some (_, [])) ->
+        Lwt.return_error
+          (f "Error: Could not find '%s' option in the field." option)
+    | Ok (_, Some _) ->
+        Lwt.return_error
+          (f "Error: Unexpected result when looking for '%s'." option)
+    | Ok (project_id, None) -> (
+        Lwt_io.printlf
+          "Required backporting field '%s' does not exist yet. Creating it..."
+          field
+        >>= fun () ->
+        GitHub_mutations.create_new_release_management_field ~bot_info
+          ~project_id ~field
+        >>= function
+        | Ok (field_id, options) -> (
+          match
+            List.find_map options ~f:(fun (option', field_value_id) ->
+                if String.equal option option' then Some field_value_id
+                else None )
+          with
+          | Some field_value_id ->
+              Lwt.return_ok (project_id, field_id, field_value_id)
+          | None ->
+              Lwt.return_error
+                (f
+                   "Error new field '%s status' was created, but does not have \
+                    a '%s' option."
+                   field option ) )
+        | Error err ->
             Lwt.return_error
-              (f
-                 "Error new field '%s status' was created, but does not have a \
-                  '%s' option."
-                 field option ) )
-      | Error err ->
-          Lwt.return_error
-            (f "Error while creating new backporting field '%s': %s" field err)
-      )
-  | Error err ->
-      Lwt.return_error (f "Error while getting project field values: %s" err) )
+              (f "Error while creating new backporting field '%s': %s" field err)
+        )
+    | Error err ->
+        Lwt.return_error (f "Error while getting project field values: %s" err)
+    )
   >>= function
   | Ok (project_id, field_id, field_value_id) -> (
       ( match id with
-      | `PR_ID card_id ->
-          GitHub_mutations.add_card_to_project ~bot_info ~card_id ~project_id
-      | `Card_ID card_id ->
-          Lwt.return_ok card_id )
+        | `PR_ID card_id ->
+            GitHub_mutations.add_card_to_project ~bot_info ~card_id ~project_id
+        | `Card_ID card_id ->
+            Lwt.return_ok card_id )
       >>= fun result ->
       match result with
       | Ok card_id ->
@@ -314,10 +321,10 @@ let pull_request_closed_action ~bot_info
   gitlab_ci_ref_for_github_pr ~bot_info ~issue:pr_info.issue.issue
     ~github_mapping ~gitlab_mapping
   >>= (function
-        | Ok remote_ref ->
-            git_delete ~remote_ref |> execute_cmd >|= ignore
-        | Error err ->
-            Lwt_io.printlf "Error: %s" err )
+  | Ok remote_ref ->
+      git_delete ~remote_ref |> execute_cmd >|= ignore
+  | Error err ->
+      Lwt_io.printlf "Error: %s" err )
   <&>
   if remove_milestone_if_not_merged && not pr_info.merged then
     Lwt_io.printf
@@ -334,27 +341,26 @@ let add_remove_labels ~bot_info ~add (issue : issue_info) labels =
     let open Lwt.Infix in
     labels
     |> Lwt_list.filter_map_p (fun label ->
-           GitHub_queries.get_label ~bot_info ~owner:issue.issue.owner
-             ~repo:issue.issue.repo ~label
-           >|= function
-           | Ok (Some label) ->
-               Some label
-           | Ok None ->
-               (* Warn when a label is not found *)
-               (fun () ->
-                 Lwt_io.printlf
-                   "Warning: Label %s not found in repository %s/%s." label
-                   issue.issue.owner issue.issue.repo )
-               |> Lwt.async ;
-               None
-           | Error err ->
-               (* Print any other error, but do not prevent acting on other labels *)
-               (fun () ->
-                 Lwt_io.printlf
-                   "Error while querying for label %s in repository %s/%s: %s"
-                   label issue.issue.owner issue.issue.repo err )
-               |> Lwt.async ;
-               None )
+        GitHub_queries.get_label ~bot_info ~owner:issue.issue.owner
+          ~repo:issue.issue.repo ~label
+        >|= function
+        | Ok (Some label) ->
+            Some label
+        | Ok None ->
+            (* Warn when a label is not found *)
+            (fun () ->
+              Lwt_io.printlf "Warning: Label %s not found in repository %s/%s."
+                label issue.issue.owner issue.issue.repo )
+            |> Lwt.async ;
+            None
+        | Error err ->
+            (* Print any other error, but do not prevent acting on other labels *)
+            (fun () ->
+              Lwt_io.printlf
+                "Error while querying for label %s in repository %s/%s: %s"
+                label issue.issue.owner issue.issue.repo err )
+            |> Lwt.async ;
+            None )
   in
   match labels with
   | [] ->

--- a/bot-components/github/GitHub_installations.ml
+++ b/bot-components/github/GitHub_installations.ml
@@ -64,7 +64,7 @@ let action_as_github_app ~bot_info ~key ~app_id ~owner action =
         match
           installs
           |> List.find_map ~f:(fun (owner', install_id) ->
-                 if String.equal owner owner' then Some install_id else None )
+              if String.equal owner owner' then Some install_id else None )
         with
         | Some install_id ->
             let _ = Hashtbl.add installation_ids ~key:owner ~data:install_id in

--- a/bot-components/github/GitHub_mutations.ml
+++ b/bot-components/github/GitHub_mutations.ml
@@ -97,10 +97,10 @@ let post_comment ~bot_info ~id ~message =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(function
-        | {payload= Some {commentEdge= Some {node= Some {url}}}} ->
-            Ok url
-        | _ ->
-            Error "Error while retrieving URL of posted comment." )
+    | {payload= Some {commentEdge= Some {node= Some {url}}}} ->
+        Ok url
+    | _ ->
+        Error "Error while retrieving URL of posted comment." )
 
 let update_milestone_issue ~bot_info ~issue ~milestone =
   let open GitHub_GraphQL.UpdateMilestoneIssue in

--- a/bot-components/github/GitHub_queries.ml
+++ b/bot-components/github/GitHub_queries.ml
@@ -25,7 +25,7 @@ let get_pull_request_cards ~bot_info ~owner ~repo ~number =
             | Some items ->
                 items |> Array.to_list |> List.filter_opt
                 |> List.map ~f:(fun item ->
-                       (GitHub_ID.of_string item.item_id, item.projectV2.number) )
+                    (GitHub_ID.of_string item.item_id, item.projectV2.number) )
           in
           Ok items
       | None ->
@@ -42,21 +42,21 @@ let get_pull_request_milestone ~bot_info ~pr_id =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(fun result ->
-          match result.node with
-          | Some (`PullRequest result) -> (
-            match result.milestone with
-            | Some milestone ->
-                Ok
-                  ( milestone.description
-                  |> Option.map ~f:(fun desc ->
-                         Utils.extract_backport_info ~bot_info ~description:desc )
-                  |> Option.value ~default:[] )
-            | None ->
-                Ok [] )
-          | Some _ ->
-              Error (f "Node %s is not a pull request." pr_id)
-          | None ->
-              Error (f "Pull request %s does not exist." pr_id) )
+      match result.node with
+      | Some (`PullRequest result) -> (
+        match result.milestone with
+        | Some milestone ->
+            Ok
+              ( milestone.description
+              |> Option.map ~f:(fun desc ->
+                  Utils.extract_backport_info ~bot_info ~description:desc )
+              |> Option.value ~default:[] )
+        | None ->
+            Ok [] )
+      | Some _ ->
+          Error (f "Node %s is not a pull request." pr_id)
+      | None ->
+          Error (f "Pull request %s does not exist." pr_id) )
 
 let get_pull_request_id_and_milestone ~bot_info ~owner ~repo ~number =
   let open GitHub_GraphQL.PullRequest_ID_and_Milestone in
@@ -65,28 +65,26 @@ let get_pull_request_id_and_milestone ~bot_info ~owner ~repo ~number =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(fun result ->
-          match result.repository with
+      match result.repository with
+      | None ->
+          Error (f "Repository %s/%s does not exist." owner repo)
+      | Some result -> (
+        match result.pullRequest with
+        | None ->
+            Error (f "Pull request %s/%s#%d does not exist." owner repo number)
+        | Some pr -> (
+          match pr.milestone with
           | None ->
-              Error (f "Repository %s/%s does not exist." owner repo)
-          | Some result -> (
-            match result.pullRequest with
-            | None ->
-                Error
-                  (f "Pull request %s/%s#%d does not exist." owner repo number)
-            | Some pr -> (
-              match pr.milestone with
-              | None ->
-                  Error
-                    (f "Pull request %s/%s#%d does not have a milestone." owner
-                       repo number )
-              | Some milestone ->
-                  Ok
-                    ( GitHub_ID.of_string pr.id
-                    , milestone.description
-                      |> Option.map ~f:(fun desc ->
-                             Utils.extract_backport_info ~bot_info
-                               ~description:desc )
-                      |> Option.value ~default:[] ) ) ) )
+              Error
+                (f "Pull request %s/%s#%d does not have a milestone." owner repo
+                   number )
+          | Some milestone ->
+              Ok
+                ( GitHub_ID.of_string pr.id
+                , milestone.description
+                  |> Option.map ~f:(fun desc ->
+                      Utils.extract_backport_info ~bot_info ~description:desc )
+                  |> Option.value ~default:[] ) ) ) )
 
 let get_pull_request_id ~bot_info ~owner ~repo ~number =
   let open GitHub_GraphQL.PullRequest_ID in
@@ -95,16 +93,15 @@ let get_pull_request_id ~bot_info ~owner ~repo ~number =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(fun result ->
-          match result.repository with
-          | None ->
-              Error (f "Repository %s/%s does not exist." owner repo)
-          | Some result -> (
-            match result.pullRequest with
-            | None ->
-                Error
-                  (f "Pull request %s/%s#%d does not exist." owner repo number)
-            | Some pr ->
-                Ok (GitHub_ID.of_string pr.id) ) )
+      match result.repository with
+      | None ->
+          Error (f "Repository %s/%s does not exist." owner repo)
+      | Some result -> (
+        match result.pullRequest with
+        | None ->
+            Error (f "Pull request %s/%s#%d does not exist." owner repo number)
+        | Some pr ->
+            Ok (GitHub_ID.of_string pr.id) ) )
 
 let get_milestone_id ~bot_info ~owner ~repo ~number =
   let open GitHub_GraphQL.Milestone_ID in
@@ -113,17 +110,17 @@ let get_milestone_id ~bot_info ~owner ~repo ~number =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(fun result ->
-          match result.repository with
-          | None ->
-              Error (f "Repository %s/%s does not exist." owner repo)
-          | Some result -> (
-            match result.milestone with
-            | None ->
-                Error
-                  (f "Milestone %d does not exist in repository %s/%s." number
-                     owner repo )
-            | Some milestone ->
-                Ok (GitHub_ID.of_string milestone.id) ) )
+      match result.repository with
+      | None ->
+          Error (f "Repository %s/%s does not exist." owner repo)
+      | Some result -> (
+        match result.milestone with
+        | None ->
+            Error
+              (f "Milestone %d does not exist in repository %s/%s." number owner
+                 repo )
+        | Some milestone ->
+            Ok (GitHub_ID.of_string milestone.id) ) )
 
 let team_membership_of_resp ~org ~team ~user resp =
   let open GitHub_GraphQL.TeamMembership in
@@ -139,10 +136,10 @@ let team_membership_of_resp ~org ~team ~user resp =
       | Some members
         when members
              |> Array.exists ~f:(function
-                  | Some member when String.equal member.login user ->
-                      true
-                  | _ ->
-                      false ) ->
+               | Some member when String.equal member.login user ->
+                   true
+               | _ ->
+                   false ) ->
           Ok true
       | _ ->
           Ok false ) )
@@ -154,7 +151,7 @@ let get_team_membership ~bot_info ~org ~team ~user =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query get_team_membership failed with %s" err )
+      f "Query get_team_membership failed with %s" err )
   >|= Result.bind ~f:(team_membership_of_resp ~org ~team ~user)
 
 let pull_request_info_of_resp ~owner ~repo ~number resp =
@@ -211,7 +208,7 @@ let get_pull_request_refs ~bot_info ~owner ~repo ~number =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query pull_request_info failed with %s" err )
+      f "Query pull_request_info failed with %s" err )
   >|= Result.bind ~f:(pull_request_info_of_resp ~owner ~repo ~number)
 
 let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
@@ -255,11 +252,11 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                      (Option.bind ~f:(fun review ->
                           review.author
                           |> Option.bind ~f:(fun author ->
-                                 match review.state with
-                                 | `APPROVED ->
-                                     Some author.login
-                                 | _ ->
-                                     None ) ) )
+                              match review.state with
+                              | `APPROVED ->
+                                  Some author.login
+                              | _ ->
+                                  None ) ) )
             in
             let comment_reviews =
               let open Reviews in
@@ -269,11 +266,11 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                      (Option.bind ~f:(fun review ->
                           review.author
                           |> Option.bind ~f:(fun author ->
-                                 if
-                                   List.mem ~equal:String.equal approved_reviews
-                                     author.login
-                                 then None
-                                 else Some author.login ) ) )
+                              if
+                                List.mem ~equal:String.equal approved_reviews
+                                  author.login
+                              then None
+                              else Some author.login ) ) )
             in
             Ok
               { baseRef= baseRef.name
@@ -291,12 +288,11 @@ let pull_request_reviews_info_of_resp ~owner ~repo ~number resp :
                   | Some comments ->
                       comments |> Array.to_list |> List.filter_opt
                       |> List.filter_map ~f:(fun c ->
-                             c.author
-                             |> Option.map ~f:(fun a : comment ->
-                                    { id= GitHub_ID.of_string c.id
-                                    ; author= a.login
-                                    ; created_by_email= c.createdViaEmail } ) )
-                  )
+                          c.author
+                          |> Option.map ~f:(fun a : comment ->
+                              { id= GitHub_ID.of_string c.id
+                              ; author= a.login
+                              ; created_by_email= c.createdViaEmail } ) ) )
               ; approved_reviews
               ; comment_reviews
               ; review_decision=
@@ -319,7 +315,7 @@ let get_pull_request_reviews_refs ~bot_info ~owner ~repo ~number =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query pull_request_reviews_info failed with %s" err )
+      f "Query pull_request_reviews_info failed with %s" err )
   >|= Result.bind ~f:(pull_request_reviews_info_of_resp ~owner ~repo ~number)
 
 let file_content_of_resp ~owner ~repo resp : (string option, string) Result.t =
@@ -364,7 +360,7 @@ let get_default_branch ~bot_info ~owner ~repo =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query get_default_branch failed with %s" err )
+      f "Query get_default_branch failed with %s" err )
   >|= Result.bind ~f:(default_branch_of_resp ~owner ~repo)
 
 let closer_info_of_pr pr =
@@ -373,7 +369,7 @@ let closer_info_of_pr pr =
   { milestone_id=
       pr.milestone
       |> Option.map ~f:(fun milestone ->
-             GitHub_ID.of_string milestone.Milestone.id )
+          GitHub_ID.of_string milestone.Milestone.id )
   ; pull_request_id= GitHub_ID.of_string pr.id }
 
 let closer_info_option_of_closer closer =
@@ -416,16 +412,16 @@ let issue_closer_info_of_resp ~owner ~repo ~number resp =
       | Some [|Some (`ClosedEvent event)|] ->
           event.closer |> closer_info_option_of_closer
           |> Result.map ~f:(function
-               | ClosedByPullRequest closer_info ->
-                   ClosedByPullRequest
-                     { issue_id= GitHub_ID.of_string issue.id
-                     ; milestone_id=
-                         issue.milestone
-                         |> Option.map ~f:(fun milestone ->
-                                GitHub_ID.of_string milestone.Milestone.id )
-                     ; closer= closer_info }
-               | (ClosedByCommit | ClosedByOther | NoCloseEvent) as reason ->
-                   reason )
+            | ClosedByPullRequest closer_info ->
+                ClosedByPullRequest
+                  { issue_id= GitHub_ID.of_string issue.id
+                  ; milestone_id=
+                      issue.milestone
+                      |> Option.map ~f:(fun milestone ->
+                          GitHub_ID.of_string milestone.Milestone.id )
+                  ; closer= closer_info }
+            | (ClosedByCommit | ClosedByOther | NoCloseEvent) as reason ->
+                reason )
       | _ ->
           Result.return NoCloseEvent ) )
 
@@ -478,7 +474,7 @@ let get_issue_closer_info ~bot_info ({owner; repo; number} : issue) =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query issue_milestone failed with %s" err )
+      f "Query issue_milestone failed with %s" err )
   >|= Result.bind ~f:(issue_closer_info_of_resp ~owner ~repo ~number)
 
 let repo_id_of_resp ~owner ~repo resp =
@@ -496,7 +492,7 @@ let get_repository_id ~bot_info ~owner ~repo =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query get_repository_id failed with %s" err )
+      f "Query get_repository_id failed with %s" err )
   >|= Result.bind ~f:(repo_id_of_resp ~owner ~repo)
 
 let get_status_check ~bot_info ~owner ~repo ~commit ~context =
@@ -506,55 +502,55 @@ let get_status_check ~bot_info ~owner ~repo ~commit ~context =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err ->
-          f "Query get_status_check failed with %s" err )
+      f "Query get_status_check failed with %s" err )
   >|= Result.bind ~f:(fun resp ->
-          match resp.repository with
-          | None ->
-              Error (f "Unknown repository %s/%s." owner repo)
-          | Some repository -> (
-            match repository.obj with
-            | Some (`Commit commit) ->
-                let check =
-                  match commit.checkSuites with
-                  | None ->
+      match resp.repository with
+      | None ->
+          Error (f "Unknown repository %s/%s." owner repo)
+      | Some repository -> (
+        match repository.obj with
+        | Some (`Commit commit) ->
+            let check =
+              match commit.checkSuites with
+              | None ->
+                  false
+              | Some checkSuites -> (
+                match checkSuites.nodes with
+                | None ->
+                    false
+                | Some checkSuites -> (
+                  match Array.to_list checkSuites with
+                  | [] | [None] | _ :: _ :: _ ->
                       false
-                  | Some checkSuites -> (
-                    match checkSuites.nodes with
+                  | [Some checkSuite] -> (
+                    match checkSuite.checkRuns with
                     | None ->
                         false
-                    | Some checkSuites -> (
-                      match Array.to_list checkSuites with
-                      | [] | [None] | _ :: _ :: _ ->
+                    | Some checkRuns -> (
+                      match checkRuns.nodes with
+                      | None ->
                           false
-                      | [Some checkSuite] -> (
-                        match checkSuite.checkRuns with
-                        | None ->
+                      | Some checkRuns -> (
+                        match Array.to_list checkRuns with
+                        | [] | [None] | _ :: _ :: _ ->
                             false
-                        | Some checkRuns -> (
-                          match checkRuns.nodes with
+                        | [Some checkRun] -> (
+                          match checkRun.databaseId with
                           | None ->
                               false
-                          | Some checkRuns -> (
-                            match Array.to_list checkRuns with
-                            | [] | [None] | _ :: _ :: _ ->
-                                false
-                            | [Some checkRun] -> (
-                              match checkRun.databaseId with
-                              | None ->
-                                  false
-                              | Some _ ->
-                                  true ) ) ) ) ) )
-                in
-                let status =
-                  match commit.status with
-                  | None ->
-                      false
-                  | Some status -> (
-                    match status.context with None -> false | Some _ -> true )
-                in
-                Ok (check || status)
-            | _ ->
-                Error (f "Unkown commit %s/%s@%s." owner repo commit) ) )
+                          | Some _ ->
+                              true ) ) ) ) ) )
+            in
+            let status =
+              match commit.status with
+              | None ->
+                  false
+              | Some status -> (
+                match status.context with None -> false | Some _ -> true )
+            in
+            Ok (check || status)
+        | _ ->
+            Error (f "Unkown commit %s/%s@%s." owner repo commit) ) )
 
 let get_check_tab_info checkRun =
   let open GitHub_GraphQL.GetBaseAndHeadChecks.CheckRuns in
@@ -577,163 +573,158 @@ let get_base_and_head_checks ~bot_info ~owner ~repo ~pr_number ~base ~head =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(fun resp ->
-          resp.repository
-          |> Result.of_option ~error:(f "Unknown repository %s/%s." owner repo) )
+      resp.repository
+      |> Result.of_option ~error:(f "Unknown repository %s/%s." owner repo) )
   >|= Result.bind ~f:(fun repository ->
-          match (repository.pullRequest, repository.base, repository.head) with
-          | None, _, _ ->
-              Error (f "Unknown pull request %s/%s#%d" owner repo pr_number)
-          | _, None, _ ->
-              Error (f "Unkown base commit %s/%s@%s." owner repo base)
-          | _, _, None ->
-              Error (f "Unkown head commit %s/%s@%s." owner repo head)
-          | _, Some (`UnspecifiedFragment _), _
-          | _, _, Some (`UnspecifiedFragment _) ->
-              Error "Unspecified fragment."
-          | Some pull_request, Some (`Commit base_obj), Some (`Commit head_obj)
-            -> (
-              let extract_check_suites checkSuites =
-                let open CheckSuites in
-                checkSuites
-                |> Option.bind ~f:(fun checkSuites -> checkSuites.nodes)
+      match (repository.pullRequest, repository.base, repository.head) with
+      | None, _, _ ->
+          Error (f "Unknown pull request %s/%s#%d" owner repo pr_number)
+      | _, None, _ ->
+          Error (f "Unkown base commit %s/%s@%s." owner repo base)
+      | _, _, None ->
+          Error (f "Unkown head commit %s/%s@%s." owner repo head)
+      | _, Some (`UnspecifiedFragment _), _ | _, _, Some (`UnspecifiedFragment _)
+        ->
+          Error "Unspecified fragment."
+      | Some pull_request, Some (`Commit base_obj), Some (`Commit head_obj) -> (
+          let extract_check_suites checkSuites =
+            let open CheckSuites in
+            checkSuites
+            |> Option.bind ~f:(fun checkSuites -> checkSuites.nodes)
+            |> Option.map ~f:Array.to_list
+            |> Option.map ~f:List.filter_opt
+          in
+          match
+            ( extract_check_suites base_obj.checkSuites
+            , extract_check_suites head_obj.checkSuites )
+          with
+          | (None | Some []), _ ->
+              Error
+                (f "No check suite %d for base commit %s/%s@%s." appId owner
+                   repo base )
+          | _, (None | Some []) ->
+              Error
+                (f "No check suite %d for head commit %s/%s@%s." appId owner
+                   repo head )
+          | Some (_ :: _ :: _), _ ->
+              Error
+                (f "Got more than one checkSuite %d for base commit %s/%s@%s."
+                   appId owner repo base )
+          | _, Some (_ :: _ :: _) ->
+              Error
+                (f "Got more than one checkSuite %d for head commit %s/%s@%s."
+                   appId owner repo head )
+          | Some [baseCheckSuite], Some [headCheckSuite] -> (
+              let extract_check_runs checkRuns =
+                let open CheckRuns in
+                checkRuns
+                |> Option.bind ~f:(fun checkRuns -> checkRuns.nodes)
                 |> Option.map ~f:Array.to_list
                 |> Option.map ~f:List.filter_opt
               in
               match
-                ( extract_check_suites base_obj.checkSuites
-                , extract_check_suites head_obj.checkSuites )
+                ( extract_check_runs baseCheckSuite.checkRuns
+                , extract_check_runs headCheckSuite.checkRuns )
               with
-              | (None | Some []), _ ->
+              | None, _ ->
                   Error
-                    (f "No check suite %d for base commit %s/%s@%s." appId owner
+                    (f "No check runs %d for base commit %s/%s@%s." appId owner
                        repo base )
-              | _, (None | Some []) ->
+              | _, None ->
                   Error
-                    (f "No check suite %d for head commit %s/%s@%s." appId owner
+                    (f "No check runs %d for head commit %s/%s@%s." appId owner
                        repo head )
-              | Some (_ :: _ :: _), _ ->
-                  Error
-                    (f
-                       "Got more than one checkSuite %d for base commit \
-                        %s/%s@%s."
-                       appId owner repo base )
-              | _, Some (_ :: _ :: _) ->
-                  Error
-                    (f
-                       "Got more than one checkSuite %d for head commit \
-                        %s/%s@%s."
-                       appId owner repo head )
-              | Some [baseCheckSuite], Some [headCheckSuite] -> (
-                  let extract_check_runs checkRuns =
-                    let open CheckRuns in
+              | Some baseCheckRuns, Some headCheckRuns ->
+                  let open CheckRuns in
+                  let completed_runs checkRuns description commit =
                     checkRuns
-                    |> Option.bind ~f:(fun checkRuns -> checkRuns.nodes)
-                    |> Option.map ~f:Array.to_list
-                    |> Option.map ~f:List.filter_opt
+                    |> List.map ~f:(fun checkRun ->
+                        match checkRun.conclusion with
+                        | None ->
+                            (* In progress *)
+                            Ok (get_check_tab_info checkRun, None)
+                        | Some conclusion -> (
+                          match conclusion with
+                          | `ACTION_REQUIRED ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "A check run (%s) requires an action for \
+                                     %s commit %s/%s@%s."
+                                    checkRun.name description owner repo commit
+                                )
+                          | `CANCELLED ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "A check run (%s) was cancelled for %s \
+                                     commit %s/%s@%s."
+                                    checkRun.name description owner repo commit
+                                )
+                          | `SKIPPED ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "A check run (%s) was skipped for %s \
+                                     commit %s/%s@%s."
+                                    checkRun.name description owner repo commit
+                                )
+                          | `STALE ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "A check run (%s) is stale for %s commit \
+                                     %s/%s@%s."
+                                    checkRun.name description owner repo commit
+                                )
+                          | `TIMED_OUT ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "A check run (%s) timed out for %s commit \
+                                     %s/%s@%s."
+                                    checkRun.name description owner repo commit
+                                )
+                          | `STARTUP_FAILURE ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "A check run (%s) failed at startup for %s \
+                                     commit %s/%s@%s."
+                                    checkRun.name description owner repo commit
+                                )
+                          | `FAILURE | `NEUTRAL ->
+                              Ok (get_check_tab_info checkRun, Some false)
+                          | `SUCCESS ->
+                              Ok (get_check_tab_info checkRun, Some true)
+                          | `FutureAddedValue status ->
+                              Error
+                                ( checkRun.name
+                                , f
+                                    "Unknown status %s for check run %s (for \
+                                     %s commit %s/%s@%s"
+                                    status checkRun.name description owner repo
+                                    commit ) ) )
                   in
-                  match
-                    ( extract_check_runs baseCheckSuite.checkRuns
-                    , extract_check_runs headCheckSuite.checkRuns )
-                  with
-                  | None, _ ->
-                      Error
-                        (f "No check runs %d for base commit %s/%s@%s." appId
-                           owner repo base )
-                  | _, None ->
-                      Error
-                        (f "No check runs %d for head commit %s/%s@%s." appId
-                           owner repo head )
-                  | Some baseCheckRuns, Some headCheckRuns ->
-                      let open CheckRuns in
-                      let completed_runs checkRuns description commit =
-                        checkRuns
-                        |> List.map ~f:(fun checkRun ->
-                               match checkRun.conclusion with
-                               | None ->
-                                   (* In progress *)
-                                   Ok (get_check_tab_info checkRun, None)
-                               | Some conclusion -> (
-                                 match conclusion with
-                                 | `ACTION_REQUIRED ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "A check run (%s) requires an \
-                                            action for %s commit %s/%s@%s."
-                                           checkRun.name description owner repo
-                                           commit )
-                                 | `CANCELLED ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "A check run (%s) was cancelled for \
-                                            %s commit %s/%s@%s."
-                                           checkRun.name description owner repo
-                                           commit )
-                                 | `SKIPPED ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "A check run (%s) was skipped for \
-                                            %s commit %s/%s@%s."
-                                           checkRun.name description owner repo
-                                           commit )
-                                 | `STALE ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "A check run (%s) is stale for %s \
-                                            commit %s/%s@%s."
-                                           checkRun.name description owner repo
-                                           commit )
-                                 | `TIMED_OUT ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "A check run (%s) timed out for %s \
-                                            commit %s/%s@%s."
-                                           checkRun.name description owner repo
-                                           commit )
-                                 | `STARTUP_FAILURE ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "A check run (%s) failed at startup \
-                                            for %s commit %s/%s@%s."
-                                           checkRun.name description owner repo
-                                           commit )
-                                 | `FAILURE | `NEUTRAL ->
-                                     Ok (get_check_tab_info checkRun, Some false)
-                                 | `SUCCESS ->
-                                     Ok (get_check_tab_info checkRun, Some true)
-                                 | `FutureAddedValue status ->
-                                     Error
-                                       ( checkRun.name
-                                       , f
-                                           "Unknown status %s for check run %s \
-                                            (for %s commit %s/%s@%s"
-                                           status checkRun.name description
-                                           owner repo commit ) ) )
-                      in
-                      let labels : string list option =
-                        let open GetChecks in
-                        let open Option in
-                        pull_request.labels
-                        >>= fun labels ->
-                        labels.nodes
-                        >>= fun labels ->
-                        Array.to_list labels
-                        |> List.filter_map
-                             ~f:(Option.map ~f:(fun label -> label.name))
-                        |> Option.return
-                      in
-                      Ok
-                        { pr_id= GitHub_ID.of_string pull_request.id
-                        ; base_checks= completed_runs baseCheckRuns "base" base
-                        ; head_checks= completed_runs headCheckRuns "head" head
-                        ; draft= pull_request.isDraft
-                        ; body= pull_request.body
-                        ; labels= Option.value ~default:[] labels } ) ) )
+                  let labels : string list option =
+                    let open GetChecks in
+                    let open Option in
+                    pull_request.labels
+                    >>= fun labels ->
+                    labels.nodes
+                    >>= fun labels ->
+                    Array.to_list labels
+                    |> List.filter_map
+                         ~f:(Option.map ~f:(fun label -> label.name))
+                    |> Option.return
+                  in
+                  Ok
+                    { pr_id= GitHub_ID.of_string pull_request.id
+                    ; base_checks= completed_runs baseCheckRuns "base" base
+                    ; head_checks= completed_runs headCheckRuns "head" head
+                    ; draft= pull_request.isDraft
+                    ; body= pull_request.body
+                    ; labels= Option.value ~default:[] labels } ) ) )
 
 let get_pipeline_summary ~bot_info ~owner ~repo ~head =
   let appId = bot_info.app_id in
@@ -743,66 +734,58 @@ let get_pipeline_summary ~bot_info ~owner ~repo ~head =
   |> send_graphql_query ~bot_info ~query
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.bind ~f:(fun resp ->
-          resp.repository
-          |> Result.of_option ~error:(f "Unknown repository %s/%s." owner repo) )
+      resp.repository
+      |> Result.of_option ~error:(f "Unknown repository %s/%s." owner repo) )
   >|= Result.bind ~f:(fun repository ->
-          match repository.getPipelineSummaryCommit with
-          | None ->
-              Error (f "Unknown head commit %s/%s@%s." owner repo head)
-          | Some (`UnspecifiedFragment _) ->
-              Error "Unspecified fragment."
-          | Some (`Commit head_obj) -> (
-              let extract_check_suites checkSuites =
-                checkSuites
-                |> Option.bind ~f:(fun checkSuites -> checkSuites.nodes)
+      match repository.getPipelineSummaryCommit with
+      | None ->
+          Error (f "Unknown head commit %s/%s@%s." owner repo head)
+      | Some (`UnspecifiedFragment _) ->
+          Error "Unspecified fragment."
+      | Some (`Commit head_obj) -> (
+          let extract_check_suites checkSuites =
+            checkSuites
+            |> Option.bind ~f:(fun checkSuites -> checkSuites.nodes)
+            |> Option.map ~f:Array.to_list
+            |> Option.map ~f:List.filter_opt
+          in
+          match extract_check_suites head_obj.checkSuites with
+          | None | Some [] ->
+              Error
+                (f "No check suite %d for head commit %s/%s@%s." appId owner
+                   repo head )
+          | Some (_ :: _ :: _) ->
+              Error
+                (f "Got more than one checkSuite %d for head commit %s/%s@%s."
+                   appId owner repo head )
+          | Some [headCheckSuite] -> (
+            match headCheckSuite.getPipelineSummaryCheckRuns with
+            | None ->
+                Error
+                  (f "No GitLab CI pipeline summary for head commit %s/%s@%s."
+                     owner repo head )
+            | Some checkRuns -> (
+              match
+                checkRuns.nodes
                 |> Option.map ~f:Array.to_list
                 |> Option.map ~f:List.filter_opt
-              in
-              match extract_check_suites head_obj.checkSuites with
+              with
               | None | Some [] ->
                   Error
-                    (f "No check suite %d for head commit %s/%s@%s." appId owner
-                       repo head )
-              | Some (_ :: _ :: _) ->
-                  Error
-                    (f
-                       "Got more than one checkSuite %d for head commit \
-                        %s/%s@%s."
-                       appId owner repo head )
-              | Some [headCheckSuite] -> (
-                match headCheckSuite.getPipelineSummaryCheckRuns with
-                | None ->
-                    Error
+                    (f "No GitLab CI pipeline summary for head commit %s/%s@%s."
+                       owner repo head )
+              | Some [headCheckRun] ->
+                  Stdlib.Option.to_result
+                    ~none:
                       (f
                          "No GitLab CI pipeline summary for head commit \
                           %s/%s@%s."
                          owner repo head )
-                | Some checkRuns -> (
-                  match
-                    checkRuns.nodes
-                    |> Option.map ~f:Array.to_list
-                    |> Option.map ~f:List.filter_opt
-                  with
-                  | None | Some [] ->
-                      Error
-                        (f
-                           "No GitLab CI pipeline summary for head commit \
-                            %s/%s@%s."
-                           owner repo head )
-                  | Some [headCheckRun] ->
-                      Stdlib.Option.to_result
-                        ~none:
-                          (f
-                             "No GitLab CI pipeline summary for head commit \
-                              %s/%s@%s."
-                             owner repo head )
-                        headCheckRun.summary
-                  | Some (_ :: _ :: _) ->
-                      Error
-                        (f
-                           "Got more than one checkRun for head commit \
-                            %s/%s@%s."
-                           owner repo head ) ) ) ) )
+                    headCheckRun.summary
+              | Some (_ :: _ :: _) ->
+                  Error
+                    (f "Got more than one checkRun for head commit %s/%s@%s."
+                       owner repo head ) ) ) ) )
 
 let get_list getter =
   let rec get_list_aux cursor accu =
@@ -914,14 +897,11 @@ let get_label ~bot_info ~owner ~repo ~label =
        ~parse:(Fn.compose parse unsafe_fromJson)
   >|= Result.map_error ~f:(fun err -> f "Query label failed with %s" err)
   >|= Result.bind ~f:(fun result ->
-          match result.repository with
-          | Some result ->
-              Ok
-                (Option.map
-                   ~f:(fun {id} -> GitHub_ID.of_string id)
-                   result.label )
-          | None ->
-              Error (f "Repository %s/%s does not exist." owner repo) )
+      match result.repository with
+      | Some result ->
+          Ok (Option.map ~f:(fun {id} -> GitHub_ID.of_string id) result.label)
+      | None ->
+          Error (f "Repository %s/%s does not exist." owner repo) )
 
 let get_pull_request_labels ~bot_info ~owner ~repo ~pr_number =
   let getter cursor =

--- a/bot-components/github/dune
+++ b/bot-components/github/dune
@@ -1,7 +1,7 @@
 (rule
  (alias update-github-schema)
  (targets github-schema.json)
- (deps ../.github-token (universe))
+ (deps ../.github-token)
  (action
   (with-stdout-to
    %{targets}

--- a/bot-components/github/dune
+++ b/bot-components/github/dune
@@ -1,4 +1,5 @@
 (rule
+ (alias update-github-schema)
  (targets github-schema.json)
  (deps ../.github-token (universe))
  (action
@@ -7,4 +8,4 @@
    (run get-graphql-schema --json --header
      "Authorization=Bearer %{read-strings:../.github-token}"
      https://api.github.com/graphql)))
- (mode promote))
+ (mode fallback))

--- a/bot-components/github/dune
+++ b/bot-components/github/dune
@@ -1,11 +1,10 @@
+; Schema files are checked in and used as source by graphql_ppx.
+; Normal `dune build` must not regenerate them.
+; Refresh with: dune build @update-schema
+
 (rule
- (alias update-github-schema)
- (targets github-schema.json)
- (deps ../.github-token)
+ (alias update-schema)
+ (deps ../.github-token (universe))
  (action
-  (with-stdout-to
-   %{targets}
-   (run get-graphql-schema --json --header
-     "Authorization=Bearer %{read-strings:../.github-token}"
-     https://api.github.com/graphql)))
- (mode fallback))
+  (run bash -c
+    "get-graphql-schema --json --header \"Authorization=Bearer %{read-strings:../.github-token}\" https://api.github.com/graphql > %{workspace_root}/../../bot-components/github/github-schema.json")))

--- a/bot-components/gitlab/GitLab_mutations.ml
+++ b/bot-components/gitlab/GitLab_mutations.ml
@@ -42,7 +42,7 @@ let play_job ~bot_info ~gitlab_domain ~project_id ~build_id
         | _ ->
             key_value_pairs
             |> List.map ~f:(fun (k, v) ->
-                   f {|{ "key": "%s", "value": "%s" }|} k v )
+                f {|{ "key": "%s", "value": "%s" }|} k v )
             |> String.concat ~sep:","
             |> f {|{ "job_variables_attributes": [%s] }|}
             |> Cohttp_lwt.Body.of_string

--- a/bot-components/gitlab/GitLab_queries.ml
+++ b/bot-components/gitlab/GitLab_queries.ml
@@ -54,7 +54,7 @@ let get_retry_nb ~bot_info ~gitlab_domain ~full_name ~build_id ~build_name =
             | Some {name= Some name} ->
                 String.equal build_name name
             | None | Some {name= None} ->
-                false ) )
+                false ))
   | Ok
       { project=
           Some

--- a/bot-components/gitlab/GitLab_subscriptions.ml
+++ b/bot-components/gitlab/GitLab_subscriptions.ml
@@ -18,10 +18,10 @@ let extract_commit json =
        is present and represents the sha. *)
     ( None
     , ( match commit_json |> member "sha" with
-      | `Null ->
-          commit_json |> member "id"
-      | sha ->
-          sha )
+        | `Null ->
+            commit_json |> member "id"
+        | sha ->
+            sha )
       |> to_string )
 
 let job_info_of_json json =
@@ -78,9 +78,9 @@ let pipeline_info_of_json json =
   let variables =
     pipeline_json |> member "variables" |> to_list
     |> List.map ~f:(fun variable ->
-           let key = variable |> member "key" |> to_string in
-           let value = variable |> member "value" |> to_string in
-           (key, value) )
+        let key = variable |> member "key" |> to_string in
+        let value = variable |> member "value" |> to_string in
+        (key, value) )
   in
   let stages =
     pipeline_json |> member "stages" |> to_list |> List.map ~f:to_string
@@ -112,11 +112,11 @@ let gitlab_event ~event json =
 let receive_gitlab ~secret headers body =
   let open Result in
   ( match Header.get headers "X-Gitlab-Token" with
-  | Some header_secret ->
-      if Eqaf.equal secret header_secret then return true
-      else Error "Webhook password mismatch."
-  | None ->
-      return false )
+    | Some header_secret ->
+        if Eqaf.equal secret header_secret then return true
+        else Error "Webhook password mismatch."
+    | None ->
+        return false )
   >>= fun signed ->
   match Header.get headers "X-Gitlab-Event" with
   | Some event -> (

--- a/bot-components/gitlab/dune
+++ b/bot-components/gitlab/dune
@@ -1,8 +1,10 @@
+; Schema files are checked in and used as source by graphql_ppx.
+; Normal `dune build` must not regenerate them.
+; Refresh with: dune build @update-schema
+
 (rule
- (alias update-gitlab-schema)
- (targets gitlab-schema.json)
+ (alias update-schema)
+ (deps (universe))
  (action
-  (with-stdout-to
-   %{targets}
-   (run get-graphql-schema https://gitlab.com/api/graphql --json)))
- (mode fallback))
+  (run bash -c
+    "get-graphql-schema https://gitlab.com/api/graphql --json > %{workspace_root}/../../bot-components/gitlab/gitlab-schema.json")))

--- a/bot-components/gitlab/dune
+++ b/bot-components/gitlab/dune
@@ -1,8 +1,9 @@
 (rule
+ (alias update-gitlab-schema)
  (targets gitlab-schema.json)
  (deps (universe))
  (action
   (with-stdout-to
    %{targets}
    (run get-graphql-schema https://gitlab.com/api/graphql --json)))
- (mode promote))
+ (mode fallback))

--- a/bot-components/gitlab/dune
+++ b/bot-components/gitlab/dune
@@ -1,7 +1,6 @@
 (rule
  (alias update-gitlab-schema)
  (targets gitlab-schema.json)
- (deps (universe))
  (action
   (with-stdout-to
    %{targets}

--- a/bot-components/graphql/GraphQL_query.ml
+++ b/bot-components/graphql/GraphQL_query.ml
@@ -8,18 +8,18 @@ let send_graphql_query ~bot_info ?(extra_headers = []) ?(ignore_errors = false)
     ~api ~query ~parse variables =
   let uri =
     ( match api with
-    | GitLab gitlab_domain ->
-        f "https://%s/api/graphql" gitlab_domain
-    | GitHub ->
-        "https://api.github.com/graphql" )
+      | GitLab gitlab_domain ->
+          f "https://%s/api/graphql" gitlab_domain
+      | GitHub ->
+          "https://api.github.com/graphql" )
     |> Uri.of_string
   in
   let open Lwt_result.Infix in
   ( match api with
-  | GitLab gitlab_domain ->
-      gitlab_name_and_token bot_info gitlab_domain
-  | GitHub ->
-      Ok (bot_info.github_name, bot_info.github_install_token) )
+    | GitLab gitlab_domain ->
+        gitlab_name_and_token bot_info gitlab_domain
+    | GitHub ->
+        Ok (bot_info.github_name, bot_info.github_install_token) )
   |> Lwt.return
   >>= fun (name, token) ->
   let headers =
@@ -55,7 +55,7 @@ let send_graphql_query ~bot_info ?(extra_headers = []) ?(ignore_errors = false)
             let errors =
               to_list errors
               |> List.map ~f:(fun error ->
-                     error |> member "message" |> to_string )
+                  error |> member "message" |> to_string )
             in
             Error
               ( "Server responded to GraphQL request with errors: "

--- a/bot-components/utils/HTTP_utils.ml
+++ b/bot-components/utils/HTTP_utils.ml
@@ -113,20 +113,19 @@ let handle_zip action body =
       >>= fun () ->
       Lwt_io.close tmp_channel
       >>= Lwt_preemptive.detach (fun () ->
-              try
-                let zip_entries =
-                  let zf = Zip.open_in tmp_name in
-                  let entries =
-                    Zip.entries zf
-                    |> List.filter ~f:(fun entry -> not entry.is_directory)
-                    |> List.map ~f:(fun entry ->
-                           (entry, Zip.read_entry zf entry) )
-                  in
-                  Zip.close_in zf ; entries
-                in
-                Ok zip_entries
-              with Zip.Error (zip_name, entry_name, message) ->
-                Error (f "Zip.Error(%s, %s, %s)" zip_name entry_name message) ) )
+          try
+            let zip_entries =
+              let zf = Zip.open_in tmp_name in
+              let entries =
+                Zip.entries zf
+                |> List.filter ~f:(fun entry -> not entry.is_directory)
+                |> List.map ~f:(fun entry -> (entry, Zip.read_entry zf entry))
+              in
+              Zip.close_in zf ; entries
+            in
+            Ok zip_entries
+          with Zip.Error (zip_name, entry_name, message) ->
+            Error (f "Zip.Error(%s, %s, %s)" zip_name entry_name message) ) )
   >|= action
 
 (******************************************************************************)

--- a/bot-components/utils/Minimize_parser.ml
+++ b/bot-components/utils/Minimize_parser.ml
@@ -54,8 +54,10 @@ let parse_minimize_text_of_body ~github_bot_name body =
     string_match
       ~regexp:
         ( f
-            "@%s:? \
-             [Mm]inimize\\([^`]*\\)```\\([^\n\r]*\\)[\r]*\n\\(\\(.\\|\n\\)+\\)"
+            "@%s:? [Mm]inimize\\([^`]*\\)```\\([^\n\
+             \r]*\\)[\r]*\n\
+             \\(\\(.\\|\n\
+             \\)+\\)"
         @@ Str.quote github_bot_name )
       body
   then
@@ -104,8 +106,13 @@ let parse_resume_ci_minimize_text_of_body ~github_bot_name body =
     string_match
       ~regexp:
         ( f
-            "@%s:?\\( [^\n] *\\)\\bresume [Cc][Ii][- \
-             ][Mm]inimiz\\(e\\|ation\\):?\\([^\n]*\\)[\r]*\n+```\\([^\n]*\\)[\r]*\n\\(\\(.\\|\n\\)+\\)"
+            "@%s:?\\( [^\n\
+             ] *\\)\\bresume [Cc][Ii][- ][Mm]inimiz\\(e\\|ation\\):?\\([^\n\
+             ]*\\)[\r]*\n\
+             +```\\([^\n\
+             ]*\\)[\r]*\n\
+             \\(\\(.\\|\n\
+             \\)+\\)"
         @@ Str.quote github_bot_name )
       body
   then
@@ -123,10 +130,11 @@ let parse_resume_ci_minimize_text_of_body ~github_bot_name body =
     string_match
       ~regexp:
         ( f
-            "@%s:?\\( [^\n]*\\)\\bresume [Cc][Ii][- \
-             ][Mm]inimiz\\(e\\|ation\\):?[ \n            ]+\\([^ \
-             \n            ]+\\)[ \n            ]+\\[\\([^]]*\\)\\] \
-             *(\\([^)]*\\))"
+            "@%s:?\\( [^\n\
+             ]*\\)\\bresume [Cc][Ii][- ][Mm]inimiz\\(e\\|ation\\):?[ \n\
+            \            ]+\\([^ \n\
+            \            ]+\\)[ \n\
+            \            ]+\\[\\([^]]*\\)\\] *(\\([^)]*\\))"
         @@ Str.quote github_bot_name )
       body
   then
@@ -144,10 +152,12 @@ let parse_resume_ci_minimize_text_of_body ~github_bot_name body =
     string_match
       ~regexp:
         ( f
-            "@%s:?\\( [^\n]*\\)\\bresume [Cc][Ii][- \
-             ][Mm]inimiz\\(e\\|ation\\):?[ \n            ]+\\([^ \
-             \n            ]+\\)[ \n            ]+\\(https?://[^ \
-             \n            ]+\\)"
+            "@%s:?\\( [^\n\
+             ]*\\)\\bresume [Cc][Ii][- ][Mm]inimiz\\(e\\|ation\\):?[ \n\
+            \            ]+\\([^ \n\
+            \            ]+\\)[ \n\
+            \            ]+\\(https?://[^ \n\
+            \            ]+\\)"
         @@ Str.quote github_bot_name )
       body
   then

--- a/src/actions/backport.ml
+++ b/src/actions/backport.ml
@@ -21,26 +21,25 @@ let rocq_push_action ~bot_info ~base_ref ~commits_msg =
       | Ok (pr_id, backport_info) ->
           backport_info
           |> Lwt_list.iter_p (fun {backport_to} ->
-                 if "refs/heads/" ^ backport_to |> String.equal base_ref then
-                   Lwt_io.printf
-                     "PR was merged into the backporting branch directly.\n"
-                   >>= fun () ->
-                   GitHub_automation.add_to_column ~bot_info ~backport_to
-                     (`PR_ID pr_id) "Shipped"
-                 else if String.equal base_ref "refs/heads/master" then
-                   (* For now, we hard code that PRs are only backported
+              if "refs/heads/" ^ backport_to |> String.equal base_ref then
+                Lwt_io.printf
+                  "PR was merged into the backporting branch directly.\n"
+                >>= fun () ->
+                GitHub_automation.add_to_column ~bot_info ~backport_to
+                  (`PR_ID pr_id) "Shipped"
+              else if String.equal base_ref "refs/heads/master" then
+                (* For now, we hard code that PRs are only backported
                       from master.  In the future, we could make this
                       configurable in the milestone description or in
                       some configuration file. *)
-                   Lwt_io.printf "Backporting to %s was requested.\n"
-                     backport_to
-                   >>= fun () ->
-                   GitHub_automation.add_to_column ~bot_info ~backport_to
-                     (`PR_ID pr_id) "Request inclusion"
-                 else
-                   Lwt_io.printf
-                     "PR was merged into a branch that is not the backporting \
-                      branch nor the master branch.\n" )
+                Lwt_io.printf "Backporting to %s was requested.\n" backport_to
+                >>= fun () ->
+                GitHub_automation.add_to_column ~bot_info ~backport_to
+                  (`PR_ID pr_id) "Request inclusion"
+              else
+                Lwt_io.printf
+                  "PR was merged into a branch that is not the backporting \
+                   branch nor the master branch.\n" )
       | Error err ->
           Lwt_io.printf "Error: %s\n" err
     else if

--- a/src/actions/job.ml
+++ b/src/actions/job.ml
@@ -34,17 +34,28 @@ let job_action ~bot_info
             let summary_builder, allow_failure_handler =
               if String.equal github_repo_full_name "rocq-prover/rocq" then
                 ( Job_status_rocq.rocq_summary_builder
-                , fun ~bot_info ~job_name ~job_url ~pr_num ~head_commit
-                      (gh_owner, gh_repo) ~gitlab_repo_full_name ->
+                , fun ~bot_info
+                    ~job_name
+                    ~job_url
+                    ~pr_num
+                    ~head_commit
+                    (gh_owner, gh_repo)
+                    ~gitlab_repo_full_name
+                  ->
                     Job_status_rocq.handle_rocq_allow_failure ~bot_info
                       ~job_name ~job_url ~pr_num ~head_commit
                       (gh_owner, gh_repo) ~gitlab_repo_full_name )
               else
                 ( (fun _trace_lines trace_description ->
                     Lwt.return trace_description )
-                , fun ~bot_info:_ ~job_name:_ ~job_url:_ ~pr_num:_
-                      ~head_commit:_ _ ~gitlab_repo_full_name:_ ->
-                    Lwt.return_unit )
+                , fun ~bot_info:_
+                    ~job_name:_
+                    ~job_url:_
+                    ~pr_num:_
+                    ~head_commit:_
+                    _
+                    ~gitlab_repo_full_name:_
+                  -> Lwt.return_unit )
             in
             Job_status.job_failure ~bot_info job_info ~pr_num
               (gh_owner, gh_repo) ~gitlab_domain ~gitlab_repo_full_name ~context

--- a/src/actions/pr_sync.ml
+++ b/src/actions/pr_sync.ml
@@ -22,9 +22,8 @@ let update_pr ?full_ci ?(skip_author_check = false) ~bot_info
   |&& git_fetch pr_info.head.branch ("refs/heads/" ^ local_head_branch)
   |> execute_cmd
   >>= (fun () ->
-        git_make_ancestor ~pr_title:pr_info.issue.title
-          ~pr_number:pr_info.issue.number ~base:local_base_branch
-          local_head_branch )
+  git_make_ancestor ~pr_title:pr_info.issue.title
+    ~pr_number:pr_info.issue.number ~base:local_base_branch local_head_branch )
   >>= fun ok ->
   let needs_full_ci_label = "needs: full CI" in
   let rebase_label = "needs: rebase" in
@@ -116,7 +115,7 @@ let update_pr ?full_ci ?(skip_author_check = false) ~bot_info
                    if
                      pr_info.issue.labels
                      |> List.exists ~f:(fun l ->
-                            String.equal l request_full_ci_label )
+                         String.equal l request_full_ci_label )
                    then (
                      (* Full CI requested *)
                      GitHub_automation.remove_labels_if_present ~bot_info
@@ -172,28 +171,26 @@ let run_ci_action ~bot_info ~comment_info ?full_ci ~gitlab_mapping
      GitHub_queries.get_team_membership ~bot_info ~org:"rocq-prover" ~team
        ~user:comment_info.author
      >>= (fun is_member ->
-           if is_member then
-             let open Lwt.Syntax in
-             let* () = Lwt_io.printl "Authorized user: pushing to GitLab." in
-             match comment_info.pull_request with
-             | Some pr_info ->
-                 update_pr ?full_ci ~skip_author_check:true pr_info ~bot_info
-                   ~gitlab_mapping ~github_mapping
-             | None ->
-                 let {owner; repo; number} = comment_info.issue.issue in
-                 GitHub_queries.get_pull_request_refs ~bot_info ~owner ~repo
-                   ~number
-                 >>= fun pr_info ->
-                 update_pr ?full_ci ~skip_author_check:true
-                   {pr_info with issue= comment_info.issue}
-                   ~bot_info ~gitlab_mapping ~github_mapping
-           else
-             (* We inform the author of the request that they are not authorized. *)
-             GitHub_automation.inform_user_not_in_contributors ~bot_info
-               ~comment_info
-             |> Lwt_result.ok )
+     if is_member then
+       let open Lwt.Syntax in
+       let* () = Lwt_io.printl "Authorized user: pushing to GitLab." in
+       match comment_info.pull_request with
+       | Some pr_info ->
+           update_pr ?full_ci ~skip_author_check:true pr_info ~bot_info
+             ~gitlab_mapping ~github_mapping
+       | None ->
+           let {owner; repo; number} = comment_info.issue.issue in
+           GitHub_queries.get_pull_request_refs ~bot_info ~owner ~repo ~number
+           >>= fun pr_info ->
+           update_pr ?full_ci ~skip_author_check:true
+             {pr_info with issue= comment_info.issue}
+             ~bot_info ~gitlab_mapping ~github_mapping
+     else
+       (* We inform the author of the request that they are not authorized. *)
+       GitHub_automation.inform_user_not_in_contributors ~bot_info ~comment_info
+       |> Lwt_result.ok )
      |> Fn.flip Lwt_result.bind_lwt_error (fun err ->
-            Lwt_io.printf "Error: %s\n" err ) )
+         Lwt_io.printf "Error: %s\n" err ) )
     >>= fun _ -> Lwt.return_unit )
   |> Lwt.async ;
   Server.respond_string ~status:`OK

--- a/src/ci/job_status.ml
+++ b/src/ci/job_status.ml
@@ -23,9 +23,14 @@ let send_status_check ~bot_info job_info ~pr_num (gh_owner, gh_repo)
     ~trace
     ?(summary_builder = fun _ trace_description -> Lwt.return trace_description)
     ?(allow_failure_handler =
-      fun ~bot_info:_ ~job_name:_ ~job_url:_ ~pr_num:_ ~head_commit:_
-          (_gh_owner, _gh_repo) ~gitlab_repo_full_name:_ ->
-        Lwt.return_unit) () =
+      fun ~bot_info:_
+        ~job_name:_
+        ~job_url:_
+        ~pr_num:_
+        ~head_commit:_
+        (_gh_owner, _gh_repo)
+        ~gitlab_repo_full_name:_
+      -> Lwt.return_unit) () =
   let job_url =
     f "https://%s/%s/-/jobs/%d" gitlab_domain gitlab_repo_full_name
       job_info.build_id
@@ -39,7 +44,7 @@ let send_status_check ~bot_info job_info ~pr_num (gh_owner, gh_repo)
         ( "Test has failed on GitLab CI"
         , trace_lines
           |> List.filter_mapi ~f:(fun i line ->
-                 if String.is_prefix ~prefix:"Error" line then Some i else None )
+              if String.is_prefix ~prefix:"Error" line then Some i else None )
           |> List.last )
     | "job_execution_timeout" ->
         ("Test has reached timeout on GitLab CI", None)

--- a/src/ci/minimization.ml
+++ b/src/ci/minimization.ml
@@ -214,7 +214,7 @@ let run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo ~pr_number
            Lwt.return_ok ()
        | Some
            (Bot_components.Minimize_parser.MinimizeScript
-             {body= bug_file_contents} ) ->
+              {body= bug_file_contents} ) ->
            Lwt_io.write bug_file_ch bug_file_contents >>= Lwt.return_ok
        | Some (MinimizeAttachment {url}) -> (
          match parse_github_artifact_url url with
@@ -279,10 +279,10 @@ let run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo ~pr_number
   >>= fun results ->
   results
   |> List.partition_map ~f:(function
-       | target, Ok () ->
-           Either.First target
-       | target, Error f ->
-           Either.Second (target, f) )
+    | target, Ok () ->
+        Either.First target
+    | target, Error f ->
+        Either.Second (target, f) )
   |> Lwt.return_ok
 
 let ci_minimization_extract_job_specific_info ~head_pipeline_summary
@@ -456,10 +456,10 @@ let fetch_ci_minimization_info ~bot_info ~owner ~repo ~pr_number
           let head_checks_errors, head_checks = partition_errors head_checks in
           head_checks_errors
           |> Lwt_list.iter_p (fun (_, error) ->
-                 Lwt_io.printlf
-                   "Non-fatal error while looking for failed tests of PR #%d \
-                    to minimize: %s"
-                   pr_number error )
+              Lwt_io.printlf
+                "Non-fatal error while looking for failed tests of PR #%d to \
+                 minimize: %s"
+                pr_number error )
           >>= fun () ->
           let extract_pipeline_check =
             List.partition3_map ~f:(fun (check_tab_info, success) ->
@@ -525,28 +525,28 @@ let fetch_ci_minimization_info ~bot_info ~owner ~repo ~pr_number
                     then Some name
                     else None )
                 @ List.filter_map head_checks_errors ~f:(fun (name, _) ->
-                      if String_utils.string_match ~regexp:"test-suite" name
-                      then Some name
-                      else None )
+                    if String_utils.string_match ~regexp:"test-suite" name then
+                      Some name
+                    else None )
               in
               let possible_jobs_to_minimize, unminimizable_jobs =
                 head_checks
                 |> List.partition_map ~f:(fun (({name}, _) as head_check) ->
-                       match
-                         ci_minimization_extract_job_specific_info
-                           ~head_pipeline_summary ~base_pipeline_summary
-                           ~base_checks_errors ~base_checks head_check
-                       with
-                       | Error err ->
-                           Either.Second (name, err)
-                       | Ok result ->
-                           Either.First result )
+                    match
+                      ci_minimization_extract_job_specific_info
+                        ~head_pipeline_summary ~base_pipeline_summary
+                        ~base_checks_errors ~base_checks head_check
+                    with
+                    | Error err ->
+                        Either.Second (name, err)
+                    | Ok result ->
+                        Either.First result )
               in
               let unminimizable_jobs =
                 unminimizable_jobs
                 @ ( unfinished_head_checks
                   |> List.map ~f:(fun {name} ->
-                         (name, f "Job %s is still in progress." name) ) )
+                      (name, f "Job %s is still in progress." name) ) )
               in
               Lwt.return_ok
                 ( { comment_thread_id= pr_id
@@ -616,7 +616,7 @@ let fetch_ci_minimization_info ~bot_info ~owner ~repo ~pr_number
                     head
                     ( head_pipeline_checks_errors
                     |> List.map ~f:(fun (name, error) ->
-                           f "- %s: %s" name error )
+                        f "- %s: %s" name error )
                     |> String.concat ~sep:"\n" ) )
           | ( ((_, _, _), _)
             , ((None, _), ((_ :: _ :: _ as pipeline_head_checks), _, _), _) ) ->
@@ -678,7 +678,7 @@ let fetch_ci_minimization_info ~bot_info ~owner ~repo ~pr_number
                     base
                     ( base_pipeline_checks_errors
                     |> List.map ~f:(fun (name, error) ->
-                           f "- %s: %s" name error )
+                        f "- %s: %s" name error )
                     |> String.concat ~sep:"\n" ) )
           | ( (((_ :: _ :: _ as pipeline_base_checks), _, _), _)
             , ((_, _), (_, _, _), _) ) ->
@@ -721,23 +721,24 @@ let minimize_failed_tests ~bot_info ~owner ~repo ~pr_number
       let unminimizable_jobs =
         unminimizable_jobs
         |> List.sort ~compare:(fun (name1, _) (name2, _) ->
-               String.compare name1 name2 )
+            String.compare name1 name2 )
       in
       possible_jobs_to_minimize
       |> List.sort ~compare:(fun (_, info1) (_, info2) ->
-             compare_minimization_info info1 info2 )
+          compare_minimization_info info1 info2 )
       |> List.map ~f:(fun (suggestion_info, minimization_info) ->
-             (ci_minimization_suggest ~base suggestion_info, minimization_info) )
+          (ci_minimization_suggest ~base suggestion_info, minimization_info) )
       |> List.partition3_map ~f:(function
-           | Suggested, minimization_info ->
-               `Fst minimization_info
-           | Possible reason, minimization_info ->
-               `Snd (reason, minimization_info)
-           | Bad reason, minimization_info ->
-               `Trd (reason, minimization_info) )
+        | Suggested, minimization_info ->
+            `Fst minimization_info
+        | Possible reason, minimization_info ->
+            `Snd (reason, minimization_info)
+        | Bad reason, minimization_info ->
+            `Trd (reason, minimization_info) )
       |> fun ( suggested_jobs_to_minimize
              , possible_jobs_to_minimize
-             , bad_jobs_to_minimize ) ->
+             , bad_jobs_to_minimize )
+      ->
       let suggested_and_possible_jobs_to_minimize =
         suggested_jobs_to_minimize
         @ List.map
@@ -769,21 +770,22 @@ let minimize_failed_tests ~bot_info ~owner ~repo ~pr_number
         | RequestExplicit requests, _ ->
             ( suggested_and_possible_jobs_to_minimize
               |> List.filter ~f:(fun {target} ->
-                     List.exists
-                       ~f:(fun request -> String.equal target request)
-                       requests )
+                  List.exists
+                    ~f:(fun request -> String.equal target request)
+                    requests )
             , Error "the user requested an explicit list of jobs" )
       in
       ( match jobs_to_minimize with
-      | [] ->
-          Lwt_io.printlf
-            "Found no jobs to initiate CI minimization on for PR #%d" pr_number
-      | _ ->
-          Lwt_io.printlf "Initiating CI minimization for PR #%d on jobs: %s"
-            pr_number
-            ( jobs_to_minimize
-            |> List.map ~f:(fun {target} -> target)
-            |> String.concat ~sep:", " ) )
+        | [] ->
+            Lwt_io.printlf
+              "Found no jobs to initiate CI minimization on for PR #%d"
+              pr_number
+        | _ ->
+            Lwt_io.printlf "Initiating CI minimization for PR #%d on jobs: %s"
+              pr_number
+              ( jobs_to_minimize
+              |> List.map ~f:(fun {target} -> target)
+              |> String.concat ~sep:", " ) )
       >>= fun () ->
       run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo
         ~pr_number:(Int.to_string pr_number) ~base ~head
@@ -816,7 +818,7 @@ let minimize_failed_tests ~bot_info ~owner ~repo ~pr_number
                   ( "The following jobs could not be minimized:\n"
                   ^ ( unminimizable_jobs
                     |> List.map ~f:(fun (name, err) ->
-                           Printf.sprintf "- %s (%s)" name err )
+                        Printf.sprintf "- %s (%s)" name err )
                     |> String.concat ~sep:"\n" )
                   ^ "\n\n" )
           in
@@ -836,7 +838,7 @@ let minimize_failed_tests ~bot_info ~owner ~repo ~pr_number
                   ( "The following jobs were not minimized:\n"
                   ^ ( bad_jobs
                     |> List.map ~f:(fun (reason, {target}) ->
-                           Printf.sprintf "- %s because %s" target reason )
+                        Printf.sprintf "- %s because %s" target reason )
                     |> String.concat ~sep:"\n" )
                   ^ "\n\n" )
           in
@@ -860,7 +862,7 @@ let minimize_failed_tests ~bot_info ~owner ~repo ~pr_number
                   ( "I failed to trigger minimization on the following jobs:\n"
                   ^ ( jobs_that_could_not_be_minimized
                     |> List.map ~f:(fun (name, err) ->
-                           Printf.sprintf "- %s (%s)" name err )
+                        Printf.sprintf "- %s (%s)" name err )
                     |> String.concat ~sep:"\n" )
                   ^ "\n\n" )
           in
@@ -913,343 +915,349 @@ let minimize_failed_tests ~bot_info ~owner ~repo ~pr_number
                 base
           in
           ( match (request, jobs_minimized, failed_minimization_description) with
-          | RequestAll, [], None ->
-              Lwt.return_some
+            | RequestAll, [], None ->
+                Lwt.return_some
+                  ( match
+                      bad_and_unminimizable_jobs_description ~f:(fun _ -> true)
+                    with
+                  | None ->
+                      f "No valid CI jobs detected for %s.%s" head try_again_msg
+                  | Some msg ->
+                      f
+                        "I attempted to run all CI jobs at commit %s for \
+                         minimization, but was unable to find any jobs to \
+                         minimize.%s\n\n\
+                         %s"
+                        head try_again_msg msg )
+            | RequestAll, _, _ ->
                 ( match
                     bad_and_unminimizable_jobs_description ~f:(fun _ -> true)
                   with
-                | None ->
-                    f "No valid CI jobs detected for %s.%s" head try_again_msg
-                | Some msg ->
-                    f
-                      "I attempted to run all CI jobs at commit %s for \
-                       minimization, but was unable to find any jobs to \
-                       minimize.%s\n\n\
-                       %s"
-                      head try_again_msg msg )
-          | RequestAll, _, _ ->
-              ( match
-                  bad_and_unminimizable_jobs_description ~f:(fun _ -> true)
-                with
-              | Some msg ->
-                  Lwt_io.printlf
-                    "When attempting to run CI Minimization by request all on \
-                     %s/%s@%s for PR #%d:\n\
-                     %s"
-                    owner repo head pr_number msg
-              | None ->
-                  Lwt.return_unit )
-              >>= fun () ->
-              ( match jobs_minimized with
-              | [] ->
-                  f
-                    "I did not succeed at triggering minimization on any jobs \
-                     at commit %s.%s"
-                    head try_again_msg
-              | _ :: _ ->
-                  (* TODO: change https://github.com/rocq-community/run-coq-bug-minimizer/actions to a link to the particular action run when we can get that information *)
-                  f
-                    "I am now [%s \
-                     minimization](https://github.com/rocq-community/run-coq-bug-minimizer/actions) \
-                     at commit %s on %s. I'll come back to you with the \
-                     results once it's done.%s"
-                    (if Option.is_none bug_file then "running" else "resuming")
-                    head
-                    (jobs_minimized |> String.concat ~sep:", ")
-                    note_some_head_unfinished_msg )
-              ^ "\n\n"
-              ^ Option.value ~default:"" failed_minimization_description
-              |> Lwt.return_some
-          | RequestExplicit requests, _, _ ->
-              (* N.B. requests may be things like library:ci-cross_crypto,
+                  | Some msg ->
+                      Lwt_io.printlf
+                        "When attempting to run CI Minimization by request all \
+                         on %s/%s@%s for PR #%d:\n\
+                         %s"
+                        owner repo head pr_number msg
+                  | None ->
+                      Lwt.return_unit )
+                >>= fun () ->
+                ( match jobs_minimized with
+                  | [] ->
+                      f
+                        "I did not succeed at triggering minimization on any \
+                         jobs at commit %s.%s"
+                        head try_again_msg
+                  | _ :: _ ->
+                      (* TODO: change https://github.com/rocq-community/run-coq-bug-minimizer/actions to a link to the particular action run when we can get that information *)
+                      f
+                        "I am now [%s \
+                         minimization](https://github.com/rocq-community/run-coq-bug-minimizer/actions) \
+                         at commit %s on %s. I'll come back to you with the \
+                         results once it's done.%s"
+                        ( if Option.is_none bug_file then "running"
+                          else "resuming" )
+                        head
+                        (jobs_minimized |> String.concat ~sep:", ")
+                        note_some_head_unfinished_msg )
+                ^ "\n\n"
+                ^ Option.value ~default:"" failed_minimization_description
+                |> Lwt.return_some
+            | RequestExplicit requests, _, _ ->
+                (* N.B. requests may be things like library:ci-cross_crypto,
                  while the job targets are things like GitLab CI job
                  library:ci-cross_crypto (pull request) *)
-              requests
-              |> List.partition3_map ~f:(fun request ->
-                     match
-                       ( List.exists
-                           ~f:
-                             (String_utils.string_match
-                                ~regexp:(Str.quote request) )
-                           jobs_minimized
-                       , List.find
-                           ~f:(fun (target, _) ->
-                             String_utils.string_match
-                               ~regexp:(Str.quote request) target )
-                           jobs_that_could_not_be_minimized
-                       , List.find
-                           ~f:(fun (target, _) ->
-                             String_utils.string_match
-                               ~regexp:(Str.quote request) target )
-                           unminimizable_jobs
-                       , List.find
-                           ~f:(fun (_, {target}) ->
-                             String_utils.string_match
-                               ~regexp:(Str.quote request) target )
-                           bad_jobs_to_minimize )
-                     with
-                     | true, _, _, _ ->
-                         `Fst request
-                     | false, Some (target, err), _, _ ->
-                         `Snd
-                           (f "%s: failed to trigger minimization (%s)" target
-                              err )
-                     | false, None, Some (target, err), _ ->
-                         `Snd (f "%s could not be minimized (%s)" target err)
-                     | false, None, None, Some (reason, {target}) ->
-                         `Snd
-                           (f "%s was not minimized because %s" target reason)
-                     | false, None, None, None ->
-                         `Trd request )
-              |> fun ( successful_requests
-                     , unsuccessful_requests
-                     , unfound_requests ) ->
-              let unsuccessful_requests_report =
-                match unsuccessful_requests with
-                | [] ->
-                    None
-                | [msg] ->
-                    Some msg
-                | _ ->
-                    Some
-                      ( "The following requests were not fulfilled:\n"
-                      ^ ( unsuccessful_requests
-                        |> List.map ~f:(fun msg -> "- " ^ msg)
-                        |> String.concat ~sep:"\n" )
-                      ^ "\n\n" )
-              in
-              let unfound_requests_report =
-                let all_jobs =
-                  List.map
-                    ~f:(fun (target, _) -> target)
-                    jobs_that_could_not_be_minimized
-                  @ List.map ~f:(fun (target, _) -> target) unminimizable_jobs
-                  @ List.map
-                      ~f:(fun (_, {target}) -> target)
-                      bad_jobs_to_minimize
-                  |> List.sort ~compare:String.compare
+                requests
+                |> List.partition3_map ~f:(fun request ->
+                    match
+                      ( List.exists
+                          ~f:
+                            (String_utils.string_match
+                               ~regexp:(Str.quote request) )
+                          jobs_minimized
+                      , List.find
+                          ~f:(fun (target, _) ->
+                            String_utils.string_match
+                              ~regexp:(Str.quote request) target )
+                          jobs_that_could_not_be_minimized
+                      , List.find
+                          ~f:(fun (target, _) ->
+                            String_utils.string_match
+                              ~regexp:(Str.quote request) target )
+                          unminimizable_jobs
+                      , List.find
+                          ~f:(fun (_, {target}) ->
+                            String_utils.string_match
+                              ~regexp:(Str.quote request) target )
+                          bad_jobs_to_minimize )
+                    with
+                    | true, _, _, _ ->
+                        `Fst request
+                    | false, Some (target, err), _, _ ->
+                        `Snd
+                          (f "%s: failed to trigger minimization (%s)" target
+                             err )
+                    | false, None, Some (target, err), _ ->
+                        `Snd (f "%s could not be minimized (%s)" target err)
+                    | false, None, None, Some (reason, {target}) ->
+                        `Snd (f "%s was not minimized because %s" target reason)
+                    | false, None, None, None ->
+                        `Trd request )
+                |> fun ( successful_requests
+                       , unsuccessful_requests
+                       , unfound_requests )
+                ->
+                let unsuccessful_requests_report =
+                  match unsuccessful_requests with
+                  | [] ->
+                      None
+                  | [msg] ->
+                      Some msg
+                  | _ ->
+                      Some
+                        ( "The following requests were not fulfilled:\n"
+                        ^ ( unsuccessful_requests
+                          |> List.map ~f:(fun msg -> "- " ^ msg)
+                          |> String.concat ~sep:"\n" )
+                        ^ "\n\n" )
                 in
-                match unfound_requests with
-                | [] ->
-                    None
-                | [request] ->
-                    Some
-                      (f
-                         "requested target '%s' could not be found among the \
-                          jobs %s.%s"
-                         request
-                         (all_jobs |> String.concat ~sep:", ")
-                         note_some_head_unfinished_msg )
-                | _ :: _ :: _ ->
-                    Some
-                      (f
-                         "requested targets %s could not be found among the \
-                          jobs %s.%s"
-                         (unfound_requests |> String.concat ~sep:", ")
-                         (all_jobs |> String.concat ~sep:", ")
-                         note_some_head_unfinished_msg )
-              in
-              let unsuccessful_requests_report =
+                let unfound_requests_report =
+                  let all_jobs =
+                    List.map
+                      ~f:(fun (target, _) -> target)
+                      jobs_that_could_not_be_minimized
+                    @ List.map ~f:(fun (target, _) -> target) unminimizable_jobs
+                    @ List.map
+                        ~f:(fun (_, {target}) -> target)
+                        bad_jobs_to_minimize
+                    |> List.sort ~compare:String.compare
+                  in
+                  match unfound_requests with
+                  | [] ->
+                      None
+                  | [request] ->
+                      Some
+                        (f
+                           "requested target '%s' could not be found among the \
+                            jobs %s.%s"
+                           request
+                           (all_jobs |> String.concat ~sep:", ")
+                           note_some_head_unfinished_msg )
+                  | _ :: _ :: _ ->
+                      Some
+                        (f
+                           "requested targets %s could not be found among the \
+                            jobs %s.%s"
+                           (unfound_requests |> String.concat ~sep:", ")
+                           (all_jobs |> String.concat ~sep:", ")
+                           note_some_head_unfinished_msg )
+                in
+                let unsuccessful_requests_report =
+                  match
+                    (unsuccessful_requests_report, unfound_requests_report)
+                  with
+                  | None, None ->
+                      None
+                  | Some msg, None ->
+                      Some msg
+                  | None, Some msg ->
+                      Some ("The " ^ msg)
+                  | Some msg1, Some msg2 ->
+                      Some (msg1 ^ "\nAdditionally, the " ^ msg2)
+                in
+                ( match (successful_requests, unsuccessful_requests_report) with
+                  | [], None ->
+                      "No CI minimization requests made?"
+                  | [], Some msg ->
+                      "I was unable to minimize any of the CI targets that you \
+                       requested." ^ try_again_msg ^ "\n" ^ msg
+                  | _ :: _, _ ->
+                      (* TODO: change https://github.com/rocq-community/run-coq-bug-minimizer/actions to a link to the particular action run when we can get that information *)
+                      f
+                        "I am now [%s \
+                         minimization](https://github.com/rocq-community/run-coq-bug-minimizer/actions) \
+                         at commit %s on requested %s %s. I'll come back to \
+                         you with the results once it's done.%s\n\n\
+                         %s"
+                        ( if Option.is_none bug_file then "running"
+                          else "resuming" )
+                        head
+                        (pluralize "target" successful_requests)
+                        (successful_requests |> String.concat ~sep:", ")
+                        note_some_base_unfinished_msg
+                        (Option.value ~default:"" unsuccessful_requests_report)
+                  )
+                |> Lwt.return_some
+            | RequestSuggested, [], None ->
+                ( match possible_jobs_to_minimize with
+                  | [] ->
+                      f
+                        "No CI jobs are available to be minimized for commit \
+                         %s.%s"
+                        head try_again_msg
+                  | _ :: _ ->
+                      f
+                        "You requested minimization of suggested failing CI \
+                         jobs, but no jobs were suggested at commit %s. You \
+                         can trigger minimization of %s with `ci minimize all` \
+                         or by requesting some targets by name.%s"
+                        head
+                        ( possible_jobs_to_minimize
+                        |> List.map ~f:(fun (_, {target}) -> target)
+                        |> String.concat ~sep:", " )
+                        may_wish_to_wait_msg )
+                |> Lwt.return_some
+            | RequestSuggested, [], Some failed_minimization_description ->
+                f
+                  "I attempted to minimize suggested failing CI jobs at commit \
+                   %s, but was unable to succeed on any jobs.%s\n\
+                   %s"
+                  head try_again_msg failed_minimization_description
+                |> Lwt.return_some
+            | RequestSuggested, _ :: _, _ ->
+                (* TODO: change https://github.com/rocq-community/run-coq-bug-minimizer/actions to a link to the particular action run when we can get that information *)
+                f
+                  "I have [initiated \
+                   minimization](https://github.com/rocq-community/run-coq-bug-minimizer/actions) \
+                   at commit %s for the suggested %s %s as requested.%s\n\n\
+                   %s"
+                  head
+                  (pluralize "target" jobs_minimized)
+                  (jobs_minimized |> String.concat ~sep:", ")
+                  try_again_msg
+                  (Option.value ~default:"" failed_minimization_description)
+                |> Lwt.return_some
+            | Auto, jobs_minimized, failed_minimization_description -> (
+                ( match
+                    bad_and_unminimizable_jobs_description ~f:(fun _ -> true)
+                  with
+                  | Some msg ->
+                      Lwt_io.printlf
+                        "When attempting to run CI Minimization by auto on \
+                         %s/%s@%s for PR #%d:\n\
+                         %s"
+                        owner repo head pr_number msg
+                  | None ->
+                      Lwt.return_unit )
+                >>= fun () ->
+                let suggest_jobs =
+                  match suggested_jobs_to_minimize with
+                  | [] ->
+                      None
+                  | _ ->
+                      Some
+                        (f
+                           ":runner: <code>@%s ci minimize</code> will \
+                            minimize the following %s: %s"
+                           bot_info.github_name
+                           (pluralize "target" suggested_jobs_to_minimize)
+                           ( suggested_jobs_to_minimize
+                           |> List.map ~f:(fun {target} -> target)
+                           |> String.concat ~sep:", " ) )
+                in
+                let suggest_only_all_jobs =
+                  let pre_message =
+                    f
+                      "- If you tag me saying `@%s ci minimize all`, I will \
+                       additionally minimize the following %s (which I do not \
+                       suggest minimizing):"
+                      bot_info.github_name
+                      (pluralize "target" possible_jobs_to_minimize)
+                  in
+                  match possible_jobs_to_minimize with
+                  | [] ->
+                      None
+                  | [(reason, {target})] ->
+                      Some
+                        (f "%s %s (because %s)\n\n\n" pre_message target reason)
+                  | _ ->
+                      Some
+                        (f "%s\n%s\n\n\n" pre_message
+                           ( possible_jobs_to_minimize
+                           |> List.map ~f:(fun (reason, {target}) ->
+                               f "  - %s (because %s)" target reason )
+                           |> String.concat ~sep:"\n" ) )
+                in
                 match
-                  (unsuccessful_requests_report, unfound_requests_report)
+                  ( jobs_minimized
+                  , failed_minimization_description
+                  , suggest_jobs
+                  , suggest_only_all_jobs
+                  , suggest_minimization )
                 with
-                | None, None ->
-                    None
-                | Some msg, None ->
-                    Some msg
-                | None, Some msg ->
-                    Some ("The " ^ msg)
-                | Some msg1, Some msg2 ->
-                    Some (msg1 ^ "\nAdditionally, the " ^ msg2)
-              in
-              ( match (successful_requests, unsuccessful_requests_report) with
-              | [], None ->
-                  "No CI minimization requests made?"
-              | [], Some msg ->
-                  "I was unable to minimize any of the CI targets that you \
-                   requested." ^ try_again_msg ^ "\n" ^ msg
-              | _ :: _, _ ->
-                  (* TODO: change https://github.com/rocq-community/run-coq-bug-minimizer/actions to a link to the particular action run when we can get that information *)
-                  f
-                    "I am now [%s \
-                     minimization](https://github.com/rocq-community/run-coq-bug-minimizer/actions) \
-                     at commit %s on requested %s %s. I'll come back to you \
-                     with the results once it's done.%s\n\n\
-                     %s"
-                    (if Option.is_none bug_file then "running" else "resuming")
-                    head
-                    (pluralize "target" successful_requests)
-                    (successful_requests |> String.concat ~sep:", ")
-                    note_some_base_unfinished_msg
-                    (Option.value ~default:"" unsuccessful_requests_report) )
-              |> Lwt.return_some
-          | RequestSuggested, [], None ->
-              ( match possible_jobs_to_minimize with
-              | [] ->
-                  f "No CI jobs are available to be minimized for commit %s.%s"
-                    head try_again_msg
-              | _ :: _ ->
-                  f
-                    "You requested minimization of suggested failing CI jobs, \
-                     but no jobs were suggested at commit %s. You can trigger \
-                     minimization of %s with `ci minimize all` or by \
-                     requesting some targets by name.%s"
-                    head
-                    ( possible_jobs_to_minimize
-                    |> List.map ~f:(fun (_, {target}) -> target)
-                    |> String.concat ~sep:", " )
-                    may_wish_to_wait_msg )
-              |> Lwt.return_some
-          | RequestSuggested, [], Some failed_minimization_description ->
-              f
-                "I attempted to minimize suggested failing CI jobs at commit \
-                 %s, but was unable to succeed on any jobs.%s\n\
-                 %s"
-                head try_again_msg failed_minimization_description
-              |> Lwt.return_some
-          | RequestSuggested, _ :: _, _ ->
-              (* TODO: change https://github.com/rocq-community/run-coq-bug-minimizer/actions to a link to the particular action run when we can get that information *)
-              f
-                "I have [initiated \
-                 minimization](https://github.com/rocq-community/run-coq-bug-minimizer/actions) \
-                 at commit %s for the suggested %s %s as requested.%s\n\n\
-                 %s"
-                head
-                (pluralize "target" jobs_minimized)
-                (jobs_minimized |> String.concat ~sep:", ")
-                try_again_msg
-                (Option.value ~default:"" failed_minimization_description)
-              |> Lwt.return_some
-          | Auto, jobs_minimized, failed_minimization_description -> (
-              ( match
-                  bad_and_unminimizable_jobs_description ~f:(fun _ -> true)
-                with
-              | Some msg ->
-                  Lwt_io.printlf
-                    "When attempting to run CI Minimization by auto on \
-                     %s/%s@%s for PR #%d:\n\
-                     %s"
-                    owner repo head pr_number msg
-              | None ->
-                  Lwt.return_unit )
-              >>= fun () ->
-              let suggest_jobs =
-                match suggested_jobs_to_minimize with
-                | [] ->
-                    None
-                | _ ->
-                    Some
-                      (f
-                         ":runner: <code>@%s ci minimize</code> will minimize \
-                          the following %s: %s"
-                         bot_info.github_name
-                         (pluralize "target" suggested_jobs_to_minimize)
-                         ( suggested_jobs_to_minimize
-                         |> List.map ~f:(fun {target} -> target)
-                         |> String.concat ~sep:", " ) )
-              in
-              let suggest_only_all_jobs =
-                let pre_message =
-                  f
-                    "- If you tag me saying `@%s ci minimize all`, I will \
-                     additionally minimize the following %s (which I do not \
-                     suggest minimizing):"
-                    bot_info.github_name
-                    (pluralize "target" possible_jobs_to_minimize)
-                in
-                match possible_jobs_to_minimize with
-                | [] ->
-                    None
-                | [(reason, {target})] ->
-                    Some
-                      (f "%s %s (because %s)\n\n\n" pre_message target reason)
-                | _ ->
-                    Some
-                      (f "%s\n%s\n\n\n" pre_message
-                         ( possible_jobs_to_minimize
-                         |> List.map ~f:(fun (reason, {target}) ->
-                                f "  - %s (because %s)" target reason )
-                         |> String.concat ~sep:"\n" ) )
-              in
-              match
-                ( jobs_minimized
-                , failed_minimization_description
-                , suggest_jobs
-                , suggest_only_all_jobs
-                , suggest_minimization )
-              with
-              | [], None, None, None, _ ->
-                  Lwt_io.printlf
-                    "No candidates found for minimization on %s/%s@%s for PR \
-                     #%d."
-                    owner repo head pr_number
-                  >>= fun () -> Lwt.return_none
-              | [], None, None, Some msg, _ ->
-                  Lwt_io.printlf
-                    "No suggested candidates found for minimization on \
-                     %s/%s@%s for PR #%d:\n\
-                     %s"
-                    owner repo head pr_number msg
-                  >>= fun () -> Lwt.return_none
-              | [], None, Some suggestion_msg, _, Error reason ->
-                  Lwt_io.printlf
-                    "Candidates found for minimization on %s/%s@%s for PR #%d, \
-                     but I am not commenting because minimization is not \
-                     suggested because %s:\n\
-                     %s\n\
-                     %s"
-                    owner repo head pr_number reason suggestion_msg
-                    (Option.value ~default:"" suggest_only_all_jobs)
-                  >>= fun () -> Lwt.return_none
-              | [], Some failed_minimization_description, _, _, _ ->
-                  Lwt_io.printlf
-                    "Candidates found for auto minimization on %s/%s@%s for PR \
-                     #%d, but all attempts to trigger minimization failed:\n\
-                     %s"
-                    owner repo head pr_number failed_minimization_description
-                  >>= fun () -> Lwt.return_none
-              | [], None, Some suggestion_msg, _, Ok () ->
-                  f
-                    ":red_circle: CI %s at commit %s without any failure in \
-                     the test-suite\n\n\
-                     :heavy_check_mark: Corresponding %s for the base commit \
-                     %s succeeded\n\n\
-                     :grey_question: Ask me to try to extract %s that can be \
-                     added to the test-suite\n\n\
-                     <details><summary>%s</summary>\n\n\
-                     - You can also pass me a specific list of targets to \
-                     minimize as arguments.\n\
-                     %s\n\
-                     </details>%s"
-                    (pluralize "failure" suggested_jobs_to_minimize)
-                    head
-                    (pluralize "job" suggested_jobs_to_minimize)
-                    base
-                    (pluralize "a minimal test case"
-                       ~plural:"minimal test cases" suggested_jobs_to_minimize )
-                    suggestion_msg
-                    (Option.value ~default:"" suggest_only_all_jobs)
-                    may_wish_to_wait_msg
-                  |> Lwt.return_some
-              | _ :: _, _, _, _, _ ->
-                  f
-                    ":red_circle: CI %s at commit %s without any failure in \
-                     the test-suite\n\n\
-                     :heavy_check_mark: Corresponding %s for the base commit \
-                     %s succeeded\n\n\
-                     <details><summary>:runner: I have automatically started \
-                     minimization for %s to augment the test-suite</summary>\n\n\
-                     - You can also pass me a specific list of targets to \
-                     minimize as arguments.\n\
-                     %s\n\
-                     </details>"
-                    (pluralize "failure" jobs_minimized)
-                    head
-                    (pluralize "job" jobs_minimized)
-                    base
-                    (jobs_minimized |> String.concat ~sep:", ")
-                    (Option.value ~default:"" suggest_only_all_jobs)
-                  |> Lwt.return_some ) )
+                | [], None, None, None, _ ->
+                    Lwt_io.printlf
+                      "No candidates found for minimization on %s/%s@%s for PR \
+                       #%d."
+                      owner repo head pr_number
+                    >>= fun () -> Lwt.return_none
+                | [], None, None, Some msg, _ ->
+                    Lwt_io.printlf
+                      "No suggested candidates found for minimization on \
+                       %s/%s@%s for PR #%d:\n\
+                       %s"
+                      owner repo head pr_number msg
+                    >>= fun () -> Lwt.return_none
+                | [], None, Some suggestion_msg, _, Error reason ->
+                    Lwt_io.printlf
+                      "Candidates found for minimization on %s/%s@%s for PR \
+                       #%d, but I am not commenting because minimization is \
+                       not suggested because %s:\n\
+                       %s\n\
+                       %s"
+                      owner repo head pr_number reason suggestion_msg
+                      (Option.value ~default:"" suggest_only_all_jobs)
+                    >>= fun () -> Lwt.return_none
+                | [], Some failed_minimization_description, _, _, _ ->
+                    Lwt_io.printlf
+                      "Candidates found for auto minimization on %s/%s@%s for \
+                       PR #%d, but all attempts to trigger minimization failed:\n\
+                       %s"
+                      owner repo head pr_number failed_minimization_description
+                    >>= fun () -> Lwt.return_none
+                | [], None, Some suggestion_msg, _, Ok () ->
+                    f
+                      ":red_circle: CI %s at commit %s without any failure in \
+                       the test-suite\n\n\
+                       :heavy_check_mark: Corresponding %s for the base commit \
+                       %s succeeded\n\n\
+                       :grey_question: Ask me to try to extract %s that can be \
+                       added to the test-suite\n\n\
+                       <details><summary>%s</summary>\n\n\
+                       - You can also pass me a specific list of targets to \
+                       minimize as arguments.\n\
+                       %s\n\
+                       </details>%s"
+                      (pluralize "failure" suggested_jobs_to_minimize)
+                      head
+                      (pluralize "job" suggested_jobs_to_minimize)
+                      base
+                      (pluralize "a minimal test case"
+                         ~plural:"minimal test cases" suggested_jobs_to_minimize )
+                      suggestion_msg
+                      (Option.value ~default:"" suggest_only_all_jobs)
+                      may_wish_to_wait_msg
+                    |> Lwt.return_some
+                | _ :: _, _, _, _, _ ->
+                    f
+                      ":red_circle: CI %s at commit %s without any failure in \
+                       the test-suite\n\n\
+                       :heavy_check_mark: Corresponding %s for the base commit \
+                       %s succeeded\n\n\
+                       <details><summary>:runner: I have automatically started \
+                       minimization for %s to augment the \
+                       test-suite</summary>\n\n\
+                       - You can also pass me a specific list of targets to \
+                       minimize as arguments.\n\
+                       %s\n\
+                       </details>"
+                      (pluralize "failure" jobs_minimized)
+                      head
+                      (pluralize "job" jobs_minimized)
+                      base
+                      (jobs_minimized |> String.concat ~sep:", ")
+                      (Option.value ~default:"" suggest_only_all_jobs)
+                    |> Lwt.return_some ) )
           >>= function
           | Some message ->
               Bot_components.GitHub_mutations.post_comment ~id:comment_thread_id
@@ -1315,29 +1323,29 @@ let run_coq_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
     (String.concat ~sep:" " minimizer_extra_arguments)
   >>= fun () ->
   ( match script with
-  | Bot_components.Minimize_parser.MinimizeScript {quote_kind; body} ->
-      if
-        List.mem ~equal:String.equal
-          ["shell"; "sh"; "shell-script"; "bash"; "zsh"]
-          (String.lowercase quote_kind)
-        || String.is_prefix ~prefix:"#!" body
-      then
-        Lwt_io.printlf "Assuming script (quote_kind: %s) is a shell script"
-          quote_kind
-        >>= fun () -> Lwt.return body
-      else
-        Lwt_io.printlf "Assuming script (quote_kind: %s) is a .v file"
-          quote_kind
-        >>= fun () ->
-        let fname = "thebug.v" in
+    | Bot_components.Minimize_parser.MinimizeScript {quote_kind; body} ->
+        if
+          List.mem ~equal:String.equal
+            ["shell"; "sh"; "shell-script"; "bash"; "zsh"]
+            (String.lowercase quote_kind)
+          || String.is_prefix ~prefix:"#!" body
+        then
+          Lwt_io.printlf "Assuming script (quote_kind: %s) is a shell script"
+            quote_kind
+          >>= fun () -> Lwt.return body
+        else
+          Lwt_io.printlf "Assuming script (quote_kind: %s) is a .v file"
+            quote_kind
+          >>= fun () ->
+          let fname = "thebug.v" in
+          Lwt.return
+            (f "#!/usr/bin/env bash\ncat > %s <<'EOF'\n%s\nEOF\ncoqc -q %s"
+               fname body fname )
+    | Bot_components.Minimize_parser.MinimizeAttachment {description; url} ->
         Lwt.return
-          (f "#!/usr/bin/env bash\ncat > %s <<'EOF'\n%s\nEOF\ncoqc -q %s" fname
-             body fname )
-  | Bot_components.Minimize_parser.MinimizeAttachment {description; url} ->
-      Lwt.return
-        ( "#!/usr/bin/env bash\n"
-        ^ Stdlib.Filename.quote_command "./handle-web-file.sh" [description; url]
-        ) )
+          ( "#!/usr/bin/env bash\n"
+          ^ Stdlib.Filename.quote_command "./handle-web-file.sh"
+              [description; url] ) )
   >>= fun script ->
   Coq.git_coq_bug_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
     ~owner ~repo ~coq_version ~ocaml_version ~minimizer_extra_arguments
@@ -1360,7 +1368,8 @@ let run_coq_minimizer ~bot_info ~script ~comment_thread_id ~comment_author
           (f
              "Error encountered when attempting to start the coq bug minimizer:\n\
               %s\n\n\
-              cc @JasonGross" e )
+              cc @JasonGross"
+             e )
         ~bot_info
       >>= Utils.report_on_posting_comment
 
@@ -1451,16 +1460,16 @@ let coq_bug_minimizer_resume_ci_minimization_action ~bot_info ~key ~app_id body
                      message
                | Ok (jobs_minimized, jobs_that_could_not_be_minimized) -> (
                    ( match jobs_minimized with
-                   | [] ->
-                       Lwt.return_unit
-                   | _ ->
-                       Lwt_io.printlf "Resuming minimization of %s"
-                         (jobs_minimized |> String.concat ~sep:", ") )
+                     | [] ->
+                         Lwt.return_unit
+                     | _ ->
+                         Lwt_io.printlf "Resuming minimization of %s"
+                           (jobs_minimized |> String.concat ~sep:", ") )
                    >>= fun () ->
                    match
                      jobs_that_could_not_be_minimized
                      |> List.map ~f:(fun (job, reason) ->
-                            f "%s because %s" job reason )
+                         f "%s because %s" job reason )
                    with
                    | [] ->
                        Lwt.return_unit

--- a/src/config/config.ml
+++ b/src/config/config.ml
@@ -27,38 +27,37 @@ let gitlab_instances toml_data =
       | Toml.Types.TTable a ->
           list_table_keys a
           |> List.map ~f:(fun k ->
-                 let bot_name =
-                   subkey_value a k "bot_name"
-                   |> Option.value ~default:(github_bot_name toml_data)
-                 in
-                 match
-                   (subkey_value a k "domain", subkey_value a k "api_token")
-                 with
-                 | None, _ ->
-                     failwith
-                       (f "Invalid gitlab.%s configuration: missing domain key."
-                          k )
-                 | Some domain, Some api_token ->
-                     (* If api_token is found, we use its value in priority *)
-                     (domain, (bot_name, api_token))
-                 | Some domain, None -> (
-                   (* Otherwise, we look for an environment variable, whose
+              let bot_name =
+                subkey_value a k "bot_name"
+                |> Option.value ~default:(github_bot_name toml_data)
+              in
+              match
+                (subkey_value a k "domain", subkey_value a k "api_token")
+              with
+              | None, _ ->
+                  failwith
+                    (f "Invalid gitlab.%s configuration: missing domain key." k)
+              | Some domain, Some api_token ->
+                  (* If api_token is found, we use its value in priority *)
+                  (domain, (bot_name, api_token))
+              | Some domain, None -> (
+                (* Otherwise, we look for an environment variable, whose
                       name is given by api_token_env_var *)
-                   match subkey_value a k "api_token_env_var" with
-                   | Some api_token_env_var ->
-                       (domain, (bot_name, Sys.getenv_exn api_token_env_var))
-                   | _ ->
-                       failwith
-                         (f
-                            "Invalid gitlab.%s configuration: missing \
-                             api_token and api_token_env_var keys."
-                            k ) ) )
+                match subkey_value a k "api_token_env_var" with
+                | Some api_token_env_var ->
+                    (domain, (bot_name, Sys.getenv_exn api_token_env_var))
+                | _ ->
+                    failwith
+                      (f
+                         "Invalid gitlab.%s configuration: missing api_token \
+                          and api_token_env_var keys."
+                         k ) ) )
       | _ ->
           failwith "Invalid gitlab configuration: not a table."
     with Stdlib.Not_found ->
       [ ( "gitlab.com"
         , (github_bot_name toml_data, Sys.getenv_exn "GITLAB_ACCESS_TOKEN") ) ]
-  )
+    )
   |> Hashtbl.of_alist_exn (module String)
 
 let github_webhook_secret toml_data =

--- a/src/utils/coq.ml
+++ b/src/utils/coq.ml
@@ -47,6 +47,10 @@ let git_run_ci_minimization ~bot_info ~comment_thread_id ~owner ~repo ~pr_number
     ; head
     ; String.concat ~sep:" " minimizer_extra_arguments ]
   @
-  match bug_file_name with Some bug_file_name -> [bug_file_name] | None -> [] )
+  match bug_file_name with
+  | Some bug_file_name ->
+      [bug_file_name]
+  | None ->
+      [] )
   |> Stdlib.Filename.quote_command "./run_ci_minimization.sh"
   |> execute_cmd ~mask:[github_pat]

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -20,8 +20,7 @@ let handle_push_event_for_repos ~bot_info ~key ~app_id ~install_id ~owner ~repo
         Bot_components.Github_installations.action_as_github_app_from_install_id
           ~bot_info ~key ~app_id ~install_id
           (mirror_action ~gitlab_domain:"gitlab.com" ~gh_owner:owner
-             ~gh_repo:repo ~gl_owner:owner ~gl_repo:repo ~base_ref ~head_sha () )
-        )
+             ~gh_repo:repo ~gl_owner:owner ~gl_repo:repo ~base_ref ~head_sha () ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK
         ~body:
@@ -37,8 +36,7 @@ let handle_push_event_for_repos ~bot_info ~key ~app_id ~install_id ~owner ~repo
         Bot_components.Github_installations.action_as_github_app_from_install_id
           ~bot_info ~key ~app_id ~install_id
           (mirror_action ~gitlab_domain:"gitlab.inria.fr" ~gh_owner:owner
-             ~gh_repo:repo ~gl_owner:owner ~gl_repo:repo ~base_ref ~head_sha () )
-        )
+             ~gh_repo:repo ~gl_owner:owner ~gl_repo:repo ~base_ref ~head_sha () ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK
         ~body:
@@ -89,8 +87,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
               ~owner:comment_info.issue.issue.owner
               ~repo:comment_info.issue.issue.repo ~options
               ~minimizer_url:
-                "https://github.com/rocq-community/run-coq-bug-minimizer/actions" )
-        )
+                "https://github.com/rocq-community/run-coq-bug-minimizer/actions" ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK ~body:"Handling minimization." ()
   | None -> (
@@ -278,8 +275,7 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
       (fun () ->
         Bot_components.Github_installations.action_as_github_app ~bot_info ~key
           ~app_id ~owner:issue.owner (fun ~bot_info ->
-            GitHub_automation.adjust_milestone ~bot_info ~issue ~sleep_time:5. )
-        )
+            GitHub_automation.adjust_milestone ~bot_info ~issue ~sleep_time:5. ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK
         ~body:
@@ -299,8 +295,7 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
       (fun () ->
         Bot_components.Github_installations.action_as_github_app_from_install_id
           ~bot_info ~key ~app_id ~install_id (fun ~bot_info ->
-            GitHub_automation.project_action ~bot_info ~pr_id ~backport_to () )
-        )
+            GitHub_automation.project_action ~bot_info ~pr_id ~backport_to () ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK
         ~body:
@@ -328,8 +323,7 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
                   ~comment_author:issue_info.user ~owner:issue_info.issue.owner
                   ~repo:issue_info.issue.repo ~options
                   ~minimizer_url:
-                    "https://github.com/rocq-community/run-coq-bug-minimizer/actions" )
-            )
+                    "https://github.com/rocq-community/run-coq-bug-minimizer/actions" ) )
           |> Lwt.async ;
           Server.respond_string ~status:`OK ~body:"Handling minimization." ()
       | None ->
@@ -363,8 +357,7 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
               ()
         | Some (gitlab_domain, url_part) ->
             (fun () ->
-              GitLab_mutations.generic_retry ~bot_info ~gitlab_domain ~url_part
-              )
+              GitLab_mutations.generic_retry ~bot_info ~gitlab_domain ~url_part )
             |> Lwt.async ;
             Server.respond_string ~status:`OK
               ~body:

--- a/tests/test_minimize_parser.ml
+++ b/tests/test_minimize_parser.ml
@@ -38,7 +38,9 @@ let test_basic_minimize () =
 
 (* Test: Minimize with no options *)
 let test_minimize_no_options () =
-  let body = "@coqbot minimize\n```bash\n#!/usr/bin/env bash\nopam install\n```" in
+  let body =
+    "@coqbot minimize\n```bash\n#!/usr/bin/env bash\nopam install\n```"
+  in
   test_minimize_parses ~name:"minimize no options" ~body ~expected_options:""
     ~expected_quote_kind:"bash"
 
@@ -63,8 +65,11 @@ let test_minimize_with_colon () =
 (* Test: The exact failing case from the issue *)
 let test_minimize_issue_case () =
   let body =
-    "@coqbot minimize\n```bash\n#!/usr/bin/env bash\nopam install -y \
-     coq-fiat-crypto\n```"
+    "@coqbot minimize\n\
+     ```bash\n\
+     #!/usr/bin/env bash\n\
+     opam install -y coq-fiat-crypto\n\
+     ```"
   in
   test_minimize_parses ~name:"issue case" ~body ~expected_options:""
     ~expected_quote_kind:"bash"
@@ -76,7 +81,9 @@ let test_minimize_no_code_block () =
 
 (* Test: CI minimize basic *)
 let test_ci_minimize_basic () =
-  match parse_ci_minimize_text_of_body ~github_bot_name "@coqbot ci minimize" with
+  match
+    parse_ci_minimize_text_of_body ~github_bot_name "@coqbot ci minimize"
+  with
   | None ->
       Alcotest.fail "ci minimize basic: expected parse to succeed"
   | Some (_, requests) when List.is_empty requests ->
@@ -88,7 +95,8 @@ let test_ci_minimize_basic () =
 (* Test: CI minimize with requests *)
 let test_ci_minimize_with_requests () =
   match
-    parse_ci_minimize_text_of_body ~github_bot_name "@coqbot ci minimize job1 job2"
+    parse_ci_minimize_text_of_body ~github_bot_name
+      "@coqbot ci minimize job1 job2"
   with
   | None ->
       Alcotest.fail "ci minimize with requests: expected parse to succeed"
@@ -96,7 +104,8 @@ let test_ci_minimize_with_requests () =
       let expected = ["job1"; "job2"] in
       if List.equal String.equal requests expected then ()
       else
-        Alcotest.failf "ci minimize with requests: expected [job1; job2], got [%s]"
+        Alcotest.failf
+          "ci minimize with requests: expected [job1; job2], got [%s]"
           (String.concat ~sep:"; " requests)
 
 (* Test: CI-minimize (hyphenated) *)


### PR DESCRIPTION
- Add missing files to `.gitignore` (credentials, generated files, editor artifacts)
- Reformat OCaml source files via `dune build @fmt --auto-promote`
- Change schema fetch rules (`github-schema.json`, `gitlab-schema.json`) from `mode promote` to `mode fallback` so `dune build` no longer triggers network fetches on every run; add named aliases (`update-github-schema`, `update-gitlab-schema`) for explicit schema refresh.