### PR TITLE
config: add per-repo TOML schema and parser

### DIFF
--- a/bot-components/utils/Utils.ml
+++ b/bot-components/utils/Utils.ml
@@ -11,6 +11,28 @@ let toml_of_file file_path = Toml.Parser.(from_filename file_path |> unsafe)
 let subkey_value toml_table k k' =
   Toml.Lenses.(get toml_table (key k |-- table |-- key k' |-- string))
 
+let subkey_table toml_table k k' =
+  Toml.Lenses.(get toml_table (key k |-- table |-- key k' |-- table))
+
+let subkey_int toml_table k k' =
+  match Toml.Lenses.(get toml_table (key k |-- table |-- key k' |-- int)) with
+  | Some n ->
+      Some n
+  | None ->
+      subkey_value toml_table k k' |> Option.map ~f:Int.of_string
+
+let key_value toml_table k = Toml.Lenses.(get toml_table (key k |-- string))
+
+let key_array toml_table k =
+  Toml.Lenses.(get toml_table (key k |-- array |-- strings))
+
+let key_bool toml_table k =
+  match Toml.Lenses.(get toml_table (key k |-- bool)) with
+  | Some b ->
+      Some b
+  | None ->
+      key_value toml_table k |> Option.map ~f:Bool.of_string
+
 let find k toml_table =
   Toml.Types.Table.find (Toml.Types.Table.Key.of_string k) toml_table
 

--- a/bot-components/utils/Utils.ml
+++ b/bot-components/utils/Utils.ml
@@ -33,6 +33,13 @@ let key_bool toml_table k =
   | None ->
       key_value toml_table k |> Option.map ~f:Bool.of_string
 
+let key_int tbl k =
+  match Toml.Lenses.(get tbl (key k |-- int)) with
+  | Some i ->
+      Some i
+  | None ->
+      key_value tbl k |> Option.map ~f:Int.of_string
+
 let find k toml_table =
   Toml.Types.Table.find (Toml.Types.Table.Key.of_string k) toml_table
 

--- a/bot-components/utils/Utils.mli
+++ b/bot-components/utils/Utils.mli
@@ -17,6 +17,8 @@ val key_array : Toml.Types.table -> string -> string list option
 
 val key_bool : Toml.Types.table -> string -> bool option
 
+val key_int : Toml.Types.table -> string -> int option
+
 val find : string -> Toml.Types.table -> Toml.Types.value
 
 val list_table_keys : Toml.Types.table -> string list

--- a/bot-components/utils/Utils.mli
+++ b/bot-components/utils/Utils.mli
@@ -6,6 +6,17 @@ val toml_of_file : string -> Toml.Types.table
 
 val subkey_value : Toml.Types.table -> string -> string -> string option
 
+val subkey_table :
+  Toml.Types.table -> string -> string -> Toml.Types.table option
+
+val subkey_int : Toml.Types.table -> string -> string -> int option
+
+val key_value : Toml.Types.table -> string -> string option
+
+val key_array : Toml.Types.table -> string -> string list option
+
+val key_bool : Toml.Types.table -> string -> bool option
+
 val find : string -> Toml.Types.table -> Toml.Types.value
 
 val list_table_keys : Toml.Types.table -> string list

--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -56,11 +56,11 @@ app_id="31373"
 
  [[repositories.rocq.teams]]
  team_name = "contributors"
- permission = "contribute"
+ permission = "trigger_ci"
 
  [[repositories.rocq.teams]]
  team_name = "pushers"
- permission = "push"
+ permission = "merge_pr"
 
  [repositories.rocq.jobs]
  # GitLab CI job name handled by bench status/results logic

--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -40,7 +40,7 @@ app_id="31373"
   gitlab_domain="gitlab.inria.fr"
 
 [repositories]
- [repositories.roqc]
+ [repositories.rocq]
  github = "rocq-prover/rocq"
  gitlab_domain = "gitlab.inria.fr"
  gitlab_owner = "coq"
@@ -49,7 +49,7 @@ app_id="31373"
  github_installation_id = 1062161
  org_name = "rocq-prover"
  team_name = "contributors"
- pushers_name = "pushers"
+ pushers_team = "pushers"
  maintainers_team = "coqbot-maintainers"
  minimizer_url = "https://github.com/rocq-community/run-coq-bug-minimizer/actions"
 

--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -45,18 +45,30 @@ app_id="31373"
  gitlab_domain = "gitlab.inria.fr"
  gitlab_owner = "coq"
  gitlab_repo = "coq"
- github_project_number = 11
  github_installation_id = 1062161
  org_name = "rocq-prover"
- team_name = "contributors"
- pushers_team = "pushers"
- maintainers_team = "coqbot-maintainers"
+ # Full GitHub @-mention used when the bot needs to alert someone
+ alert_mention = "@rocq-prover/coqbot-maintainers"
  minimizer_url = "https://github.com/rocq-community/run-coq-bug-minimizer/actions"
 
+ [repositories.rocq.backporting]
+ github_project_number = 11
+
+ [[repositories.rocq.teams]]
+ team_name = "contributors"
+ permission = "contribute"
+
+ [[repositories.rocq.teams]]
+ team_name = "pushers"
+ permission = "push"
+
  [repositories.rocq.jobs]
- bench = "bench"
- custom_job_status = true
- doc_jobs = [
+ # GitLab CI job name handled by bench status/results logic
+ bench_job = "bench"
+ # Use Rocq-specific failure summaries / allow-failure handling
+ use_rocq_job_status = true
+ # Successful jobs that get a GitHub status check linking to doc artifacts
+ doc_artifact_jobs = [
   "doc:refman", "doc:ci-refman", "doc:init",
   "doc:stdlib", "doc:stdlib:dune", "doc:ml-api:odoc"
  ]

--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -38,3 +38,25 @@ app_id="31373"
   github="math-comp/docker-mathcomp"
   gitlab="math-comp/docker-mathcomp"
   gitlab_domain="gitlab.inria.fr"
+
+[repositories]
+ [repositories.roqc]
+ github = "rocq-prover/rocq"
+ gitlab_domain = "gitlab.inria.fr"
+ gitlab_owner = "coq"
+ gitlab_repo = "coq"
+ github_project_number = 11
+ github_installation_id = 1062161
+ org_name = "rocq-prover"
+ team_name = "contributors"
+ pushers_name = "pushers"
+ maintainers_team = "coqbot-maintainers"
+ minimizer_url = "https://github.com/rocq-community/run-coq-bug-minimizer/actions"
+
+ [repositories.rocq.jobs]
+ bench = "bench"
+ custom_job_status = true
+ doc_jobs = [
+  "doc:refman", "doc:ci-refman", "doc:init",
+  "doc:stdlib", "doc:stdlib:dune", "doc:ml-api:odoc"
+ ]

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -31,6 +31,8 @@ let bot_info : Bot_components.Bot_info.t =
 
 let github_mapping, gitlab_mapping = Config.make_mappings_table toml_data
 
+let repo_config_table = Repo_config.make_repo_config_table toml_data
+
 (* TODO: deprecate unsigned webhooks *)
 
 let callback _conn req body =

--- a/src/config/dune
+++ b/src/config/dune
@@ -3,4 +3,4 @@
  (public_name coq-bot.config)
  (libraries base bot-components stdio toml)
  (wrapped false)
- (modules config))
+ (modules config repo_config))

--- a/src/config/repo_config.ml
+++ b/src/config/repo_config.ml
@@ -2,7 +2,13 @@ open Base
 open Utils
 
 type repo_jobs_config =
-  {bench: string option; custom_job_status: bool; doc_jobs: string list}
+  { bench_job: string option
+  ; use_rocq_job_status: bool
+  ; doc_artifact_jobs: string list }
+
+type backport_config = {github_project_number: int option}
+
+type team_permission = {team_name: string; permission: string}
 
 type t =
   { github_owner: string
@@ -10,29 +16,55 @@ type t =
   ; gitlab_domain: string option
   ; gitlab_owner: string option
   ; gitlab_repo: string option
-  ; github_project_number: int option
+  ; backporting: backport_config
   ; github_installation_id: int option
   ; org_name: string option
-  ; team_name: string option
-  ; pushers_team: string option
-  ; maintainers_team: string option
+  ; alert_mention: string option
+  ; teams: team_permission list
   ; minimizer_url: string option
   ; jobs: repo_jobs_config }
 
-let default_jobs = {bench= None; custom_job_status= false; doc_jobs= []}
+let default_jobs =
+  {bench_job= None; use_rocq_job_status= false; doc_artifact_jobs= []}
+
+let default_backporting = {github_project_number= None}
 
 let parse_jobs tbl key =
   match subkey_table tbl key "jobs" with
   | None ->
       default_jobs
   | Some jobs_tbl ->
-      { bench=
-          key_value jobs_tbl "bench"
+      { bench_job=
+          key_value jobs_tbl "bench_job"
           |> Option.bind ~f:(fun s ->
               if String.is_empty s then None else Some s )
-      ; custom_job_status=
-          key_bool jobs_tbl "custom_job_status" |> Option.value ~default:false
-      ; doc_jobs= key_array jobs_tbl "doc_jobs" |> Option.value ~default:[] }
+      ; use_rocq_job_status=
+          key_bool jobs_tbl "use_rocq_job_status" |> Option.value ~default:false
+      ; doc_artifact_jobs=
+          key_array jobs_tbl "doc_artifact_jobs" |> Option.value ~default:[] }
+
+let parse_backporting tbl key =
+  match subkey_table tbl key "backporting" with
+  | None ->
+      default_backporting
+  | Some bp_tbl ->
+      {github_project_number= key_int bp_tbl "github_project_number"}
+
+let parse_teams tbl k =
+  match
+    Toml.Lenses.(get tbl (key k |-- table |-- key "teams" |-- array |-- tables))
+  with
+  | None ->
+      []
+  | Some team_tables ->
+      List.filter_map team_tables ~f:(fun team_tbl ->
+          match
+            (key_value team_tbl "team_name", key_value team_tbl "permission")
+          with
+          | Some team_name, Some permission ->
+              Some {team_name; permission}
+          | _ ->
+              None )
 
 let parse_one tbl key =
   match subkey_value tbl key "github" with
@@ -47,12 +79,11 @@ let parse_one tbl key =
           ; gitlab_domain= subkey_value tbl key "gitlab_domain"
           ; gitlab_owner= subkey_value tbl key "gitlab_owner"
           ; gitlab_repo= subkey_value tbl key "gitlab_repo"
-          ; github_project_number= subkey_int tbl key "github_project_number"
+          ; backporting= parse_backporting tbl key
           ; github_installation_id= subkey_int tbl key "github_installation_id"
           ; org_name= subkey_value tbl key "org_name"
-          ; team_name= subkey_value tbl key "team_name"
-          ; pushers_team= subkey_value tbl key "pushers_team"
-          ; maintainers_team= subkey_value tbl key "maintainers_team"
+          ; alert_mention= subkey_value tbl key "alert_mention"
+          ; teams= parse_teams tbl key
           ; minimizer_url= subkey_value tbl key "minimizer_url"
           ; jobs= parse_jobs tbl key }
       | _ ->

--- a/src/config/repo_config.ml
+++ b/src/config/repo_config.ml
@@ -1,0 +1,79 @@
+open Base
+open Utils
+
+type repo_jobs_config =
+  {bench: string option; custom_job_status: bool; doc_jobs: string list}
+
+type t =
+  { github_owner: string
+  ; github_repo: string
+  ; gitlab_domain: string option
+  ; gitlab_owner: string option
+  ; gitlab_repo: string option
+  ; github_project_number: int option
+  ; github_installation_id: int option
+  ; org_name: string option
+  ; team_name: string option
+  ; pushers_team: string option
+  ; maintainers_team: string option
+  ; minimizer_url: string option
+  ; jobs: repo_jobs_config }
+
+let default_jobs = {bench= None; custom_job_status= false; doc_jobs= []}
+
+let parse_jobs tbl key =
+  match subkey_table tbl key "jobs" with
+  | None ->
+      default_jobs
+  | Some jobs_tbl ->
+      { bench=
+          key_value jobs_tbl "bench"
+          |> Option.bind ~f:(fun s ->
+              if String.is_empty s then None else Some s )
+      ; custom_job_status=
+          key_bool jobs_tbl "custom_job_status" |> Option.value ~default:false
+      ; doc_jobs= key_array jobs_tbl "doc_jobs" |> Option.value ~default:[] }
+
+let parse_one tbl key =
+  match subkey_value tbl key "github" with
+  | None ->
+      failwith (f "repositories.%s: missing required 'github' key" key)
+  | Some github -> (
+      let parts = String.split ~on:'/' github in
+      match parts with
+      | [owner; repo] ->
+          { github_owner= owner
+          ; github_repo= repo
+          ; gitlab_domain= subkey_value tbl key "gitlab_domain"
+          ; gitlab_owner= subkey_value tbl key "gitlab_owner"
+          ; gitlab_repo= subkey_value tbl key "gitlab_repo"
+          ; github_project_number= subkey_int tbl key "github_project_number"
+          ; github_installation_id= subkey_int tbl key "github_installation_id"
+          ; org_name= subkey_value tbl key "org_name"
+          ; team_name= subkey_value tbl key "team_name"
+          ; pushers_team= subkey_value tbl key "pushers_team"
+          ; maintainers_team= subkey_value tbl key "maintainers_team"
+          ; minimizer_url= subkey_value tbl key "minimizer_url"
+          ; jobs= parse_jobs tbl key }
+      | _ ->
+          failwith
+            (f "repositories.%s: 'github' must be 'owner/repo', got '%s'" key
+               github ) )
+
+let make_repo_config_table toml_data =
+  ( try
+      match find "repositories" toml_data with
+      | Toml.Types.TTable a ->
+          list_table_keys a |> List.map ~f:(fun k -> (k, parse_one a k))
+      | _ ->
+          failwith "Invalid repositories configuration: not a table."
+    with Stdlib.Not_found -> [] )
+  |> Hashtbl.of_alist_exn (module String)
+
+let find_by_github ~owner ~repo tbl =
+  Hashtbl.to_alist tbl
+  |> List.find_map ~f:(fun (_key, cfg) ->
+      if
+        String.equal cfg.github_owner owner && String.equal cfg.github_repo repo
+      then Some cfg
+      else None )

--- a/src/config/repo_config.mli
+++ b/src/config/repo_config.mli
@@ -1,0 +1,22 @@
+type repo_jobs_config =
+  {bench: string option; custom_job_status: bool; doc_jobs: string list}
+
+type t =
+  { github_owner: string
+  ; github_repo: string
+  ; gitlab_domain: string option
+  ; gitlab_owner: string option
+  ; gitlab_repo: string option
+  ; github_project_number: int option
+  ; github_installation_id: int option
+  ; org_name: string option
+  ; team_name: string option
+  ; pushers_team: string option
+  ; maintainers_team: string option
+  ; minimizer_url: string option
+  ; jobs: repo_jobs_config }
+
+val make_repo_config_table : Toml.Types.table -> (string, t) Base.Hashtbl.t
+
+val find_by_github :
+  owner:string -> repo:string -> (string, t) Base.Hashtbl.t -> t option

--- a/src/config/repo_config.mli
+++ b/src/config/repo_config.mli
@@ -1,5 +1,11 @@
 type repo_jobs_config =
-  {bench: string option; custom_job_status: bool; doc_jobs: string list}
+  { bench_job: string option
+  ; use_rocq_job_status: bool
+  ; doc_artifact_jobs: string list }
+
+type backport_config = {github_project_number: int option}
+
+type team_permission = {team_name: string; permission: string}
 
 type t =
   { github_owner: string
@@ -7,12 +13,11 @@ type t =
   ; gitlab_domain: string option
   ; gitlab_owner: string option
   ; gitlab_repo: string option
-  ; github_project_number: int option
+  ; backporting: backport_config
   ; github_installation_id: int option
   ; org_name: string option
-  ; team_name: string option
-  ; pushers_team: string option
-  ; maintainers_team: string option
+  ; alert_mention: string option
+  ; teams: team_permission list
   ; minimizer_url: string option
   ; jobs: repo_jobs_config }
 

--- a/tests/dune
+++ b/tests/dune
@@ -25,6 +25,11 @@
    test_helpers))
 
 (test
+ (name test_repo_config)
+ (modules test_repo_config)
+ (libraries alcotest bot-components coq-bot.config base))
+
+(test
  (name test_pat_usage)
  (modules test_pat_usage)
  (libraries alcotest bot-components coq-bot.utils base test_helpers))

--- a/tests/test_repo_config.ml
+++ b/tests/test_repo_config.ml
@@ -1,0 +1,79 @@
+open Base
+open Alcotest
+
+let parse s = Repo_config.make_repo_config_table (Utils.toml_of_string s)
+
+let test_full_config () =
+  let toml =
+    {|
+    [repositories.rocq]
+    github = "rocq-prover/rocq"
+    gitlab_domain = "gitlab.inria.fr"
+    gitlab_owner = "coq"
+    gitlab_repo = "coq"
+    github_project_number = 11
+    github_installation_id = 1062161
+    org_name = "rocq-prover"
+    team_name = "contributors"
+    pushers_team = "pushers"
+    maintainers_team = "coqbot-maintainers"
+    minimizer_url = "https://example.com"
+
+    [repositories.rocq.jobs]
+    bench = "bench"
+    custom_job_status = true
+    doc_jobs = ["doc:refman", "doc:stdlib"]
+    |}
+  in
+  let tbl = parse toml in
+  match Repo_config.find_by_github ~owner:"rocq-prover" ~repo:"rocq" tbl with
+  | None ->
+      fail "expected config"
+  | Some cfg ->
+      (check int) "project" 11 (Option.value_exn cfg.github_project_number) ;
+      (check (option string)) "bench" (Some "bench") cfg.jobs.bench ;
+      (check bool) "custom" true cfg.jobs.custom_job_status ;
+      (check int) "doc_jobs" 2 (List.length cfg.jobs.doc_jobs)
+
+let test_minimal_config () =
+  let tbl = parse {|
+  [repositories.demo]
+  github = "my-org/my-repo"
+  |} in
+  match Repo_config.find_by_github ~owner:"my-org" ~repo:"my-repo" tbl with
+  | None ->
+      fail "expected config"
+  | Some cfg ->
+      (check (option int)) "project" None cfg.github_project_number ;
+      (check bool) "custom" false cfg.jobs.custom_job_status ;
+      (check (list string)) "doc_jobs" [] cfg.jobs.doc_jobs
+
+let test_bad_github () =
+  check_raises "bad github"
+    (Failure "repositories.demo: 'github' must be 'owner/repo', got 'bad'")
+    (fun () -> ignore (parse {|
+  [repositories.demo]
+  github = "bad"
+  |} ) )
+
+let test_missing_section () =
+  let tbl = parse "" in
+  (check int) "empty" 0 (Hashtbl.length tbl)
+
+let test_find_miss () =
+  let tbl = parse {|
+  [repositories.demo]
+  github = "my-org/my-repo"
+|} in
+  (check bool) "miss" true
+    (Option.is_none
+       (Repo_config.find_by_github ~owner:"other" ~repo:"repo" tbl) )
+
+let () =
+  run "Repo_config tests"
+    [ ( "parse"
+      , [ ("full config", `Quick, test_full_config)
+        ; ("minimal config", `Quick, test_minimal_config)
+        ; ("bad github", `Quick, test_bad_github)
+        ; ("missing section", `Quick, test_missing_section)
+        ; ("find miss", `Quick, test_find_miss) ] ) ]

--- a/tests/test_repo_config.ml
+++ b/tests/test_repo_config.ml
@@ -11,18 +11,26 @@ let test_full_config () =
     gitlab_domain = "gitlab.inria.fr"
     gitlab_owner = "coq"
     gitlab_repo = "coq"
-    github_project_number = 11
     github_installation_id = 1062161
     org_name = "rocq-prover"
-    team_name = "contributors"
-    pushers_team = "pushers"
-    maintainers_team = "coqbot-maintainers"
+    alert_mention = "@rocq-prover/coqbot-maintainers"
     minimizer_url = "https://example.com"
 
+    [repositories.rocq.backporting]
+    github_project_number = 11
+
+    [[repositories.rocq.teams]]
+    team_name = "contributors"
+    permission = "contribute"
+
+    [[repositories.rocq.teams]]
+    team_name = "pushers"
+    permission = "push"
+
     [repositories.rocq.jobs]
-    bench = "bench"
-    custom_job_status = true
-    doc_jobs = ["doc:refman", "doc:stdlib"]
+    bench_job = "bench"
+    use_rocq_job_status = true
+    doc_artifact_jobs = ["doc:refman", "doc:stdlib"]
     |}
   in
   let tbl = parse toml in
@@ -30,10 +38,14 @@ let test_full_config () =
   | None ->
       fail "expected config"
   | Some cfg ->
-      (check int) "project" 11 (Option.value_exn cfg.github_project_number) ;
-      (check (option string)) "bench" (Some "bench") cfg.jobs.bench ;
-      (check bool) "custom" true cfg.jobs.custom_job_status ;
-      (check int) "doc_jobs" 2 (List.length cfg.jobs.doc_jobs)
+      (check (option int))
+        "project" (Some 11) cfg.backporting.github_project_number ;
+      (check (option string))
+        "alert" (Some "@rocq-prover/coqbot-maintainers") cfg.alert_mention ;
+      (check int) "teams" 2 (List.length cfg.teams) ;
+      (check (option string)) "bench_job" (Some "bench") cfg.jobs.bench_job ;
+      (check bool) "use_rocq_job_status" true cfg.jobs.use_rocq_job_status ;
+      (check int) "doc_artifact_jobs" 2 (List.length cfg.jobs.doc_artifact_jobs)
 
 let test_minimal_config () =
   let tbl = parse {|
@@ -44,9 +56,9 @@ let test_minimal_config () =
   | None ->
       fail "expected config"
   | Some cfg ->
-      (check (option int)) "project" None cfg.github_project_number ;
-      (check bool) "custom" false cfg.jobs.custom_job_status ;
-      (check (list string)) "doc_jobs" [] cfg.jobs.doc_jobs
+      (check (option int)) "project" None cfg.backporting.github_project_number ;
+      (check bool) "use_rocq_job_status" false cfg.jobs.use_rocq_job_status ;
+      (check (list string)) "doc_artifact_jobs" [] cfg.jobs.doc_artifact_jobs
 
 let test_bad_github () =
   check_raises "bad github"


### PR DESCRIPTION
## Summary
- Add `[repositories.*]` config for per-repo settings (project number, teams, jobs, minimizer URL, etc.)
- Add `Repo_config` parser + lookup helpers, and load the table at bot startup
- Extend Utils with TOML helpers for nested tables, ints, bools, and string arrays

No behavior change yet: hardcoded repo checks are unchanged. Later PRs will switch actions/webhooks to this config.

## Test plan
- [x] `dune build`
- [x] `dune exec tests/test_repo_config.exe` (full/minimal/bad github/missing section/find miss)
- [x] Confirm existing bot startup still works with the updated `coqbot-config.toml`