### PR TITLE
Allow passing configuration options to the `bench` command

### DIFF
--- a/bot-components/utils/String_utils.ml
+++ b/bot-components/utils/String_utils.ml
@@ -48,6 +48,110 @@ let first_line_of_string s =
 let remove_between s i j =
   String.sub ~pos:0 ~len:i s ^ String.sub s ~pos:j ~len:(String.length s - j)
 
+let split_shell_words ~preserve_syntax input =
+  let is_whitespace = function
+    | ' ' | '\t' | '\n' | '\r' | '\011' | '\012' ->
+        true
+    | _ ->
+        false
+  in
+  let buffer = Buffer.create (String.length input) in
+  let add_syntax char = if preserve_syntax then Buffer.add_char buffer char in
+  let finish_token token_started tokens =
+    if token_started then Buffer.contents buffer :: tokens else tokens
+  in
+  let length = String.length input in
+  let rec split index quote token_started tokens =
+    if index = length then
+      match quote with
+      | Some delimiter ->
+          Error (Printf.sprintf "unterminated %c quote" delimiter)
+      | None ->
+          Ok (List.rev (finish_token token_started tokens))
+    else
+      let char = input.[index] in
+      match quote with
+      | None when is_whitespace char ->
+          let tokens = finish_token token_started tokens in
+          Buffer.clear buffer ;
+          split (index + 1) None false tokens
+      | None when Char.equal char '\\' ->
+          if index + 1 = length then Error "trailing escape character"
+          else
+            let escaped = input.[index + 1] in
+            if Char.equal escaped '\n' then
+              split (index + 2) None token_started tokens
+            else (
+              add_syntax char ;
+              Buffer.add_char buffer escaped ;
+              split (index + 2) None true tokens )
+      | None when Char.equal char '\'' || Char.equal char '"' ->
+          add_syntax char ;
+          split (index + 1) (Some char) true tokens
+      | None ->
+          Buffer.add_char buffer char ;
+          split (index + 1) None true tokens
+      | Some '\'' when Char.equal char '\'' ->
+          add_syntax char ;
+          split (index + 1) None true tokens
+      | Some '\'' ->
+          Buffer.add_char buffer char ;
+          split (index + 1) quote true tokens
+      | Some '"' when Char.equal char '"' ->
+          add_syntax char ;
+          split (index + 1) None true tokens
+      | Some '"' when Char.equal char '\\' ->
+          if index + 1 = length then Error "unterminated \" quote"
+          else
+            let escaped = input.[index + 1] in
+            if Char.equal escaped '\n' then
+              split (index + 2) quote true tokens
+            else if
+              List.mem ['"'; '\\'; '$'; '`'] escaped ~equal:Char.equal
+            then (
+              add_syntax char ;
+              Buffer.add_char buffer escaped ;
+              split (index + 2) quote true tokens )
+            else (
+              Buffer.add_char buffer char ;
+              split (index + 1) quote true tokens )
+      | Some '"' ->
+          Buffer.add_char buffer char ;
+          split (index + 1) quote true tokens
+      | Some _ ->
+          failwith "unsupported quote delimiter"
+  in
+  split 0 None false []
+
+let split_on_unquoted_whitespace input =
+  split_shell_words ~preserve_syntax:true input
+
+let parse_key_value_arguments input =
+  match split_shell_words ~preserve_syntax:false input with
+  | Error _ as error ->
+      error
+  | Ok arguments ->
+      let rec parse parsed = function
+        | [] ->
+            Ok (List.rev parsed)
+        | argument :: arguments -> (
+          match Stdlib.String.index_opt argument '=' with
+          | None when String.is_empty argument ->
+              Error (Printf.sprintf "argument %S has an empty key" argument)
+          | None ->
+              parse ((argument, None) :: parsed) arguments
+          | Some 0 ->
+              Error (Printf.sprintf "argument %S has an empty key" argument)
+          | Some separator ->
+              let key = String.sub argument ~pos:0 ~len:separator in
+              let value =
+                String.sub argument ~pos:(separator + 1)
+                  ~len:(String.length argument - separator - 1)
+              in
+              parse ((key, Some value) :: parsed) arguments )
+      in
+      parse [] arguments
+
 (******************************************************************************)
 (* Formatting Functions                                                       *)
 (******************************************************************************)

--- a/bot-components/utils/String_utils.ml
+++ b/bot-components/utils/String_utils.ml
@@ -67,7 +67,9 @@ let split_shell_words ~preserve_syntax input =
     if index = length then
       match quote with
       | Some delimiter ->
-          Error (Printf.sprintf "unterminated %c quote" (match delimiter with Single -> '\'' | Double -> '"'))
+          Error
+            (Printf.sprintf "unterminated %c quote"
+               (match delimiter with Single -> '\'' | Double -> '"') )
       | None ->
           Ok (List.rev (finish_token token_started tokens))
     else
@@ -109,10 +111,8 @@ let split_shell_words ~preserve_syntax input =
           if index + 1 = length then Error "unterminated \" quote"
           else
             let escaped = input.[index + 1] in
-            if Char.equal escaped '\n' then
-              split (index + 2) quote true tokens
-            else if
-              List.mem ['"'; '\\'; '$'; '`'] escaped ~equal:Char.equal
+            if Char.equal escaped '\n' then split (index + 2) quote true tokens
+            else if List.mem ['"'; '\\'; '$'; '`'] escaped ~equal:Char.equal
             then (
               add_syntax char ;
               Buffer.add_char buffer escaped ;

--- a/bot-components/utils/String_utils.ml
+++ b/bot-components/utils/String_utils.ml
@@ -48,6 +48,8 @@ let first_line_of_string s =
 let remove_between s i j =
   String.sub ~pos:0 ~len:i s ^ String.sub s ~pos:j ~len:(String.length s - j)
 
+type quote = Single | Double
+
 let split_shell_words ~preserve_syntax input =
   let is_whitespace = function
     | ' ' | '\t' | '\n' | '\r' | '\011' | '\012' ->
@@ -65,7 +67,7 @@ let split_shell_words ~preserve_syntax input =
     if index = length then
       match quote with
       | Some delimiter ->
-          Error (Printf.sprintf "unterminated %c quote" delimiter)
+          Error (Printf.sprintf "unterminated %c quote" (match delimiter with Single -> '\'' | Double -> '"'))
       | None ->
           Ok (List.rev (finish_token token_started tokens))
     else
@@ -85,22 +87,25 @@ let split_shell_words ~preserve_syntax input =
               add_syntax char ;
               Buffer.add_char buffer escaped ;
               split (index + 2) None true tokens )
-      | None when Char.equal char '\'' || Char.equal char '"' ->
+      | None when Char.equal char '\'' ->
           add_syntax char ;
-          split (index + 1) (Some char) true tokens
+          split (index + 1) (Some Single) true tokens
+      | None when Char.equal char '"' ->
+          add_syntax char ;
+          split (index + 1) (Some Double) true tokens
       | None ->
           Buffer.add_char buffer char ;
           split (index + 1) None true tokens
-      | Some '\'' when Char.equal char '\'' ->
+      | Some Single when Char.equal char '\'' ->
           add_syntax char ;
           split (index + 1) None true tokens
-      | Some '\'' ->
+      | Some Single ->
           Buffer.add_char buffer char ;
           split (index + 1) quote true tokens
-      | Some '"' when Char.equal char '"' ->
+      | Some Double when Char.equal char '"' ->
           add_syntax char ;
           split (index + 1) None true tokens
-      | Some '"' when Char.equal char '\\' ->
+      | Some Double when Char.equal char '\\' ->
           if index + 1 = length then Error "unterminated \" quote"
           else
             let escaped = input.[index + 1] in
@@ -115,11 +120,9 @@ let split_shell_words ~preserve_syntax input =
             else (
               Buffer.add_char buffer char ;
               split (index + 1) quote true tokens )
-      | Some '"' ->
+      | Some Double ->
           Buffer.add_char buffer char ;
           split (index + 1) quote true tokens
-      | Some _ ->
-          failwith "unsupported quote delimiter"
   in
   split 0 None false []
 

--- a/bot-components/utils/String_utils.mli
+++ b/bot-components/utils/String_utils.mli
@@ -23,6 +23,22 @@ val first_line_of_string : string -> string
 
 val remove_between : string -> int -> int -> string
 
+(** [split_on_unquoted_whitespace input] splits [input] at ASCII whitespace
+    outside single or double quotes. Shell quote and escape syntax is recognized
+    and preserved in the returned tokens.
+
+    Returns an error for an unterminated quote or a trailing backslash. *)
+val split_on_unquoted_whitespace : string -> (string list, string) Result.t
+
+(** [parse_key_value_arguments input] parses shell-style [key=value] words.
+    Quote and escape syntax is consumed. A missing equal sign produces a [None]
+    value; an equal sign produces [Some value], including [Some ""] for an
+    explicitly empty value. Values may contain additional equal signs.
+
+    Returns an error if quoting is malformed or an argument has an empty key. *)
+val parse_key_value_arguments :
+  string -> ((string * string option) list, string) Result.t
+
 (* ========================================================================== *)
 (* Formatting Functions *)
 (* ========================================================================== *)

--- a/bot-components/utils/String_utils.mli
+++ b/bot-components/utils/String_utils.mli
@@ -23,21 +23,21 @@ val first_line_of_string : string -> string
 
 val remove_between : string -> int -> int -> string
 
+val split_on_unquoted_whitespace : string -> (string list, string) Result.t
 (** [split_on_unquoted_whitespace input] splits [input] at ASCII whitespace
     outside single or double quotes. Shell quote and escape syntax is recognized
     and preserved in the returned tokens.
 
     Returns an error for an unterminated quote or a trailing backslash. *)
-val split_on_unquoted_whitespace : string -> (string list, string) Result.t
 
+val parse_key_value_arguments :
+  string -> ((string * string option) list, string) Result.t
 (** [parse_key_value_arguments input] parses shell-style [key=value] words.
     Quote and escape syntax is consumed. A missing equal sign produces a [None]
     value; an equal sign produces [Some value], including [Some ""] for an
     explicitly empty value. Values may contain additional equal signs.
 
     Returns an error if quoting is malformed or an argument has an empty key. *)
-val parse_key_value_arguments :
-  string -> ((string * string option) list, string) Result.t
 
 (* ========================================================================== *)
 (* Formatting Functions *)

--- a/src/utils/bench.ml
+++ b/src/utils/bench.ml
@@ -7,6 +7,77 @@ open HTTP_utils
 open String_utils
 open Lwt.Infix
 
+type args = (string * string option) list
+
+let parse ~github_bot_name body =
+  if
+    string_match
+      ~regexp:
+        ( f "@%s:? [Bb]ench\\( *$\\| +\\(.*\\(\n.+\\)*\\)\\(\n\n\\|$\\)\\)"
+        @@ Str.quote github_bot_name )
+      body
+  then
+    match Str.matched_group 2 body with
+    | exception _ ->
+        Some (Result.Ok [])
+    | args ->
+        Some
+          (Result.map_error (parse_key_value_arguments args) ~f:(fun error ->
+               f "bench command could not parse key-value arguments: %s" error )
+          )
+  else None
+
+let%test "parses a command without arguments" =
+  match parse ~github_bot_name:"coqbot" "@coqbot bench" with
+  | Some (Result.Ok []) ->
+      true
+  | _ ->
+      false
+
+let%test "parses arguments through the end of the comment" =
+  match
+    parse ~github_bot_name:"coqbot"
+      "@coqbot bench coq_native\ncoq_opam_packages=\"a b\""
+  with
+  | Some (Result.Ok [("coq_native", None); ("coq_opam_packages", Some "a b")])
+    ->
+      true
+  | _ ->
+      false
+
+let%test "parses multiline arguments until an empty line" =
+  match
+    parse ~github_bot_name:"coqbot"
+      "@coqbot: Bench coq_native=yes\n\
+       coq_opam_packages='a b'\n\n\
+       This text is not part of the command."
+  with
+  | Some
+      (Result.Ok [("coq_native", Some "yes"); ("coq_opam_packages", Some "a b")])
+    ->
+      true
+  | _ ->
+      false
+
+let%test "reports malformed arguments" =
+  match
+    parse ~github_bot_name:"coqbot" "@coqbot bench value=\"unterminated"
+  with
+  | Some
+      (Result.Error
+         "bench command could not parse key-value arguments: unterminated \" \
+          quote" ) ->
+      true
+  | _ ->
+      false
+
+let%test "does not parse another command" =
+  match parse ~github_bot_name:"coqbot" "@coqbot benchmark" with
+  | None ->
+      true
+  | Some _ ->
+      false
+
 let parse_quantity table table_name =
   let regexp = {|.*TOP \([0-9]*\)|} in
   if string_match ~regexp table then

--- a/src/utils/bench.mli
+++ b/src/utils/bench.mli
@@ -1,5 +1,9 @@
 open Base
 
+type args = (string * string option) list
+
+val parse : github_bot_name:string -> string -> (args, string) Result.t option
+
 module BenchResults : sig
   type t =
     { summary_table: string

--- a/src/utils/dune
+++ b/src/utils/dune
@@ -2,5 +2,8 @@
  (name utils)
  (public_name coq-bot.utils)
  (libraries base bot-components)
+ (inline_tests)
+ (preprocess
+  (pps ppx_expect))
  (wrapped false)
  (modules bench coq))

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -151,17 +151,10 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
     in
     let parse () =
       let open Option in
-      let rec first_success body fns =
-        match fns with
-        | fn :: fns ->
-          let res = fn body in
-          if Option.is_some res then res else first_success body fns
-        | [] -> None
-      in
     (* Since both ci minimization resumption and ci minimization will match the
        resumption string, and we don't want to parse "resume" as an option, we
        test resumption first *)
-      first_success body [
+      List.find_map ~f:(fun fn -> fn body) [
         (fun body -> resume_ci_minimize_text_of_body body >>| fun x -> ResumeMinimize x);
         (fun body -> ci_minimize_text_of_body body >>| fun x -> Minimize x);
         parse_run_ci;

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -120,24 +120,18 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
        None
     in
 
-    let parse_bench_native body =
-      if
-        string_match
-          ~regexp:(f "@%s:? [Bb]ench native" @@ Str.quote github_bot_name)
-          body
-      then
-        Some `BenchNative
-      else
-        None
-    in
-
     let parse_bench body =
       if
         string_match
-          ~regexp:(f "@%s:? [Bb]ench" @@ Str.quote github_bot_name)
+          ~regexp:(f {|@%s:? [Bb]ench\( *$\| +\([^\n]+\) *\(\n\|$\)\)|} @@ Str.quote github_bot_name)
           body
       then
-        Some `Bench
+        match Str.matched_group 2 body with
+        | exception _ -> Some (`Bench [])
+        | args ->
+          match parse_key_value_arguments args with
+          | Result.Ok args -> Some (`Bench args)
+          | _ -> None
       else
         None
     in
@@ -158,7 +152,6 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
         (fun body -> ci_minimize_text_of_body body >>| fun x -> `Minimize x);
         parse_run_ci;
         parse_merge;
-        parse_bench_native;
         parse_bench
       ]
     in
@@ -227,15 +220,20 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
       Server.respond_string ~status:`OK
         ~body:(f "Received a request to start the bench.")
         ()
-    | Some `Bench when
+    | Some (`Bench args) when
             comment_info.issue.pull_request
             && String.equal comment_info.issue.issue.owner "rocq-prover"
             && String.equal comment_info.issue.issue.repo "rocq"
             && Option.is_some install_id ->
+      let key_value_pairs = List.map ~f:(fun (k,v) -> (k, Option.value ~default:"yes" v)) args in
       (fun () ->
          Bot_components.Github_installations.action_as_github_app ~bot_info
            ~key ~app_id ~owner:comment_info.issue.issue.owner
-           (fun ~bot_info -> Bench.run_bench ~bot_info comment_info ) )
+           (fun ~bot_info ->
+              Bench.run_bench ~bot_info
+                ~key_value_pairs
+                comment_info )
+      )
       |> Lwt.async ;
       Server.respond_string ~status:`OK
         ~body:(f "Received a request to start the bench.")

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -75,6 +75,7 @@ module Commands = struct
     | Bench of bench_args
     | ResumeMinimize of (string * string list * Minimize_parser.minimize_parsed)
     | Minimize of (string * string list)
+    | ParseError of string
 end
 
 open Commands
@@ -113,14 +114,11 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
             @@ Str.quote github_bot_name )
         body
       then
-        let full_ci =
-          match Str.matched_group 1 body with
-          | "full" -> Some true
-          | "light" -> Some false
-          | "" -> None
-          | _ -> failwith "Impossible group value."
-        in
-        Some (RunCI {full_ci})
+        match Str.matched_group 1 body with
+        | "full" -> Some (RunCI {full_ci=Some true})
+        | "light" -> Some (RunCI {full_ci=Some false})
+        | "" -> Some (RunCI {full_ci=None})
+        | conf -> Some (ParseError (f "run ci command: unknown CI configuration %S" conf))
       else
         None
     in
@@ -145,7 +143,8 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
         | args ->
           match parse_key_value_arguments args with
           | Result.Ok args -> Some (Bench args)
-          | _ -> None
+          | Result.Error error ->
+            Some (ParseError (f "bench command could not parse key-value arguments: %s" error))
       else
         None
     in
@@ -229,6 +228,14 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
       Server.respond_string ~status:`OK
         ~body:(f "Received a request to start the bench.")
         ()
+    | Some (ParseError error) ->
+      (fun () ->
+         GitHub_mutations.post_comment ~bot_info
+           ~message:(error)
+           ~id:comment_info.issue.id
+         >>= Utils.report_on_posting_comment)
+      |> Lwt.async;
+      Server.respond_string ~status:`OK ~body:"Invalid bench arguments." ()
     | Some (RunCI _ | Merge | Bench _) ->
       Server.respond_string ~status:`OK
         ~body:"Command recognized but not allowed in this context."

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -236,7 +236,11 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
       Server.respond_string ~status:`OK
         ~body:(f "Received a request to start the bench.")
         ()
-    | _ ->
+    | Some (RunCI _ | Merge | Bench _) ->
+      Server.respond_string ~status:`OK
+        ~body:"Command recognized but not allowed in this context."
+        ()
+    | None ->
       Server.respond_string ~status:`OK
         ~body:(f "Unhandled comment: %s" body)
         ()

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -66,11 +66,10 @@ let handle_push_event_for_repos ~bot_info ~key ~app_id ~install_id ~owner ~repo
       Server.respond_string ~status:`OK ~body:"Ignoring push event." ()
 
 module Commands = struct
-
   type bench_args = (string * string option) list
 
   type t =
-    | RunCI of { full_ci : bool option }
+    | RunCI of {full_ci: bool option}
     | Merge
     | Bench of bench_args
     | ResumeMinimize of (string * string list * Minimize_parser.minimize_parsed)
@@ -105,145 +104,153 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
                 "https://github.com/rocq-community/run-coq-bug-minimizer/actions" ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK ~body:"Handling minimization." ()
-  | None ->
-
-    let parse_run_ci body =
-      if string_match
-        ~regexp:
-          ( f "@%s:? [Rr]un \\(full\\|light\\|\\) ?[Cc][Ii]"
-            @@ Str.quote github_bot_name )
-        body
-      then
-        match Str.matched_group 1 body with
-        | "full" -> Some (RunCI {full_ci=Some true})
-        | "light" -> Some (RunCI {full_ci=Some false})
-        | "" -> Some (RunCI {full_ci=None})
-        | conf -> Some (ParseError (f "run ci command: unknown CI configuration %S" conf))
-      else
-        None
-    in
-   let parse_merge body =
-     if string_match
-       ~regexp:(f "@%s:? [Mm]erge now" @@ Str.quote github_bot_name)
-       body
-     then
-       Some Merge
-     else
-       None
-    in
-
-    let parse_bench body =
-      if
-        string_match
-          ~regexp:(f {|@%s:? [Bb]ench\( *$\| +\([^\n]+\) *\(\n\|$\)\)|} @@ Str.quote github_bot_name)
-          body
-      then
-        match Str.matched_group 2 body with
-        | exception _ -> Some (Bench [])
-        | args ->
-          match parse_key_value_arguments args with
-          | Result.Ok args -> Some (Bench args)
-          | Result.Error error ->
-            Some (ParseError (f "bench command could not parse key-value arguments: %s" error))
-      else
-        None
-    in
-    let parse () =
-      let open Option in
-    (* Since both ci minimization resumption and ci minimization will match the
+  | None -> (
+      let parse_run_ci body =
+        if
+          string_match
+            ~regexp:
+              ( f "@%s:? [Rr]un \\(full\\|light\\|\\) ?[Cc][Ii]"
+              @@ Str.quote github_bot_name )
+            body
+        then
+          match Str.matched_group 1 body with
+          | "full" ->
+              Some (RunCI {full_ci= Some true})
+          | "light" ->
+              Some (RunCI {full_ci= Some false})
+          | "" ->
+              Some (RunCI {full_ci= None})
+          | conf ->
+              Some
+                (ParseError
+                   (f "run ci command: unknown CI configuration %S" conf) )
+        else None
+      in
+      let parse_merge body =
+        if
+          string_match
+            ~regexp:(f "@%s:? [Mm]erge now" @@ Str.quote github_bot_name)
+            body
+        then Some Merge
+        else None
+      in
+      let parse_bench body =
+        if
+          string_match
+            ~regexp:
+              ( f {|@%s:? [Bb]ench\( *$\| +\([^\n]+\) *\(\n\|$\)\)|}
+              @@ Str.quote github_bot_name )
+            body
+        then
+          match Str.matched_group 2 body with
+          | exception _ ->
+              Some (Bench [])
+          | args -> (
+            match parse_key_value_arguments args with
+            | Result.Ok args ->
+                Some (Bench args)
+            | Result.Error error ->
+                Some
+                  (ParseError
+                     (f "bench command could not parse key-value arguments: %s"
+                        error ) ) )
+        else None
+      in
+      let parse () =
+        let open Option in
+        (* Since both ci minimization resumption and ci minimization will match the
        resumption string, and we don't want to parse "resume" as an option, we
        test resumption first *)
-      List.find_map ~f:(fun fn -> fn body) [
-        (fun body -> resume_ci_minimize_text_of_body body >>| fun x -> ResumeMinimize x);
-        (fun body -> ci_minimize_text_of_body body >>| fun x -> Minimize x);
-        parse_run_ci;
-        parse_merge;
-        parse_bench
-      ]
-    in
-    match parse () with
-    | Some (ResumeMinimize (options, requests, bug_file)) ->
-      (fun () ->
-        init_git_bare_repository ~bot_info
-        >>= fun () ->
-        Bot_components.Github_installations.action_as_github_app ~bot_info
-          ~key ~app_id ~owner:comment_info.issue.issue.owner (fun ~bot_info ->
-            Minimization.ci_minimize ~bot_info ~comment_info ~requests
-              ~comment_on_error:true ~options ~bug_file:(Some bug_file) ) )
-      |> Lwt.async ;
-      Server.respond_string ~status:`OK
-        ~body:"Handling CI minimization resumption." ()
-    | Some (Minimize (options, requests)) ->
-      (fun () ->
-         init_git_bare_repository ~bot_info
-         >>= fun () ->
-         Bot_components.Github_installations.action_as_github_app ~bot_info
-           ~key ~app_id ~owner:comment_info.issue.issue.owner
-           (fun ~bot_info ->
-              Minimization.ci_minimize ~bot_info ~comment_info ~requests
-                ~comment_on_error:true ~options ~bug_file:None ) )
-      |> Lwt.async ;
-      Server.respond_string ~status:`OK ~body:"Handling CI minimization." ()
-    | Some (RunCI {full_ci}) when
-        comment_info.issue.pull_request
-        && String.equal comment_info.issue.issue.owner "rocq-prover"
-        && String.equal comment_info.issue.issue.repo "rocq"
-        && Option.is_some install_id ->
-      init_git_bare_repository ~bot_info
-      >>= fun () ->
-      Bot_components.Github_installations.action_as_github_app ~bot_info
-        ~key ~app_id ~owner:comment_info.issue.issue.owner
-        (Pr_sync.run_ci_action ~comment_info ?full_ci ~gitlab_mapping
-           ~github_mapping () )
-    | Some Merge when
-        comment_info.issue.pull_request
-        && String.equal comment_info.issue.issue.owner "rocq-prover"
-        && String.equal comment_info.issue.issue.repo "rocq"
-        && Option.is_some install_id ->
-      (fun () ->
-         Bot_components.Github_installations.action_as_github_app ~bot_info
-           ~key ~app_id ~owner:comment_info.issue.issue.owner
-           (fun ~bot_info ->
-              GitHub_automation.merge_pull_request_action ~bot_info
-                comment_info ) )
-      |> Lwt.async ;
-      Server.respond_string ~status:`OK
-        ~body:(f "Received a request to merge the PR.")
-        ()
-    | Some (Bench args) when
-            comment_info.issue.pull_request
-            && String.equal comment_info.issue.issue.owner "rocq-prover"
-            && String.equal comment_info.issue.issue.repo "rocq"
-            && Option.is_some install_id ->
-      let key_value_pairs = List.map ~f:(fun (k,v) -> (k, Option.value ~default:"yes" v)) args in
-      (fun () ->
-         Bot_components.Github_installations.action_as_github_app ~bot_info
-           ~key ~app_id ~owner:comment_info.issue.issue.owner
-           (fun ~bot_info ->
-              Bench.run_bench ~bot_info
-                ~key_value_pairs
-                comment_info )
-      )
-      |> Lwt.async ;
-      Server.respond_string ~status:`OK
-        ~body:(f "Received a request to start the bench.")
-        ()
-    | Some (ParseError error) ->
-      (fun () ->
-         GitHub_mutations.post_comment ~bot_info
-           ~message:(error)
-           ~id:comment_info.issue.id
-         >>= Utils.report_on_posting_comment)
-      |> Lwt.async;
-      Server.respond_string ~status:`OK ~body:"Invalid bench arguments." ()
-    | Some (RunCI _ | Merge | Bench _) ->
-      Server.respond_string ~status:`OK
-        ~body:"Command recognized but not allowed in this context."
-        ()
-    | None ->
-      Server.respond_string ~status:`OK
-        ~body:(f "Unhandled comment: %s" body)
-        ()
+        List.find_map
+          ~f:(fun fn -> fn body)
+          [ (fun body ->
+              resume_ci_minimize_text_of_body body >>| fun x -> ResumeMinimize x )
+          ; (fun body -> ci_minimize_text_of_body body >>| fun x -> Minimize x)
+          ; parse_run_ci
+          ; parse_merge
+          ; parse_bench ]
+      in
+      match parse () with
+      | Some (ResumeMinimize (options, requests, bug_file)) ->
+          (fun () ->
+            init_git_bare_repository ~bot_info
+            >>= fun () ->
+            Bot_components.Github_installations.action_as_github_app ~bot_info
+              ~key ~app_id ~owner:comment_info.issue.issue.owner
+              (fun ~bot_info ->
+                Minimization.ci_minimize ~bot_info ~comment_info ~requests
+                  ~comment_on_error:true ~options ~bug_file:(Some bug_file) ) )
+          |> Lwt.async ;
+          Server.respond_string ~status:`OK
+            ~body:"Handling CI minimization resumption." ()
+      | Some (Minimize (options, requests)) ->
+          (fun () ->
+            init_git_bare_repository ~bot_info
+            >>= fun () ->
+            Bot_components.Github_installations.action_as_github_app ~bot_info
+              ~key ~app_id ~owner:comment_info.issue.issue.owner
+              (fun ~bot_info ->
+                Minimization.ci_minimize ~bot_info ~comment_info ~requests
+                  ~comment_on_error:true ~options ~bug_file:None ) )
+          |> Lwt.async ;
+          Server.respond_string ~status:`OK ~body:"Handling CI minimization." ()
+      | Some (RunCI {full_ci})
+        when comment_info.issue.pull_request
+             && String.equal comment_info.issue.issue.owner "rocq-prover"
+             && String.equal comment_info.issue.issue.repo "rocq"
+             && Option.is_some install_id ->
+          init_git_bare_repository ~bot_info
+          >>= fun () ->
+          Bot_components.Github_installations.action_as_github_app ~bot_info
+            ~key ~app_id ~owner:comment_info.issue.issue.owner
+            (Pr_sync.run_ci_action ~comment_info ?full_ci ~gitlab_mapping
+               ~github_mapping () )
+      | Some Merge
+        when comment_info.issue.pull_request
+             && String.equal comment_info.issue.issue.owner "rocq-prover"
+             && String.equal comment_info.issue.issue.repo "rocq"
+             && Option.is_some install_id ->
+          (fun () ->
+            Bot_components.Github_installations.action_as_github_app ~bot_info
+              ~key ~app_id ~owner:comment_info.issue.issue.owner
+              (fun ~bot_info ->
+                GitHub_automation.merge_pull_request_action ~bot_info
+                  comment_info ) )
+          |> Lwt.async ;
+          Server.respond_string ~status:`OK
+            ~body:(f "Received a request to merge the PR.")
+            ()
+      | Some (Bench args)
+        when comment_info.issue.pull_request
+             && String.equal comment_info.issue.issue.owner "rocq-prover"
+             && String.equal comment_info.issue.issue.repo "rocq"
+             && Option.is_some install_id ->
+          let key_value_pairs =
+            List.map ~f:(fun (k, v) -> (k, Option.value ~default:"yes" v)) args
+          in
+          (fun () ->
+            Bot_components.Github_installations.action_as_github_app ~bot_info
+              ~key ~app_id ~owner:comment_info.issue.issue.owner
+              (fun ~bot_info ->
+                Bench.run_bench ~bot_info ~key_value_pairs comment_info ) )
+          |> Lwt.async ;
+          Server.respond_string ~status:`OK
+            ~body:(f "Received a request to start the bench.")
+            ()
+      | Some (ParseError error) ->
+          (fun () ->
+            GitHub_mutations.post_comment ~bot_info ~message:error
+              ~id:comment_info.issue.id
+            >>= Utils.report_on_posting_comment )
+          |> Lwt.async ;
+          Server.respond_string ~status:`OK ~body:"Invalid bench arguments." ()
+      | Some (RunCI _ | Merge | Bench _) ->
+          Server.respond_string ~status:`OK
+            ~body:"Command recognized but not allowed in this context." ()
+      | None ->
+          Server.respond_string ~status:`OK
+            ~body:(f "Unhandled comment: %s" body)
+            () )
 
 let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
     ~gitlab_mapping ~github_mapping ~repo_config_table ~github_webhook_secret

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -65,6 +65,20 @@ let handle_push_event_for_repos ~bot_info ~key ~app_id ~install_id ~owner ~repo
   | _ ->
       Server.respond_string ~status:`OK ~body:"Ignoring push event." ()
 
+module Commands = struct
+
+  type bench_args = (string * string option) list
+
+  type t =
+    | RunCI of { full_ci : bool option }
+    | Merge
+    | Bench of bench_args
+    | ResumeMinimize of (string * string list * Minimize_parser.minimize_parsed)
+    | Minimize of (string * string list)
+end
+
+open Commands
+
 (* Handles all comment-related events (minimization, CI commands, bench commands, etc.)*)
 let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
     ~gitlab_mapping ~github_mapping ~install_id
@@ -106,7 +120,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
           | "" -> None
           | _ -> failwith "Impossible group value."
         in
-        Some (`RunCI full_ci)
+        Some (RunCI {full_ci})
       else
         None
     in
@@ -115,7 +129,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
        ~regexp:(f "@%s:? [Mm]erge now" @@ Str.quote github_bot_name)
        body
      then
-       Some `Merge
+       Some Merge
      else
        None
     in
@@ -127,10 +141,10 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
           body
       then
         match Str.matched_group 2 body with
-        | exception _ -> Some (`Bench [])
+        | exception _ -> Some (Bench [])
         | args ->
           match parse_key_value_arguments args with
-          | Result.Ok args -> Some (`Bench args)
+          | Result.Ok args -> Some (Bench args)
           | _ -> None
       else
         None
@@ -148,15 +162,15 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
        resumption string, and we don't want to parse "resume" as an option, we
        test resumption first *)
       first_success body [
-        (fun body -> resume_ci_minimize_text_of_body body >>| fun x -> `ResumeMinimize x);
-        (fun body -> ci_minimize_text_of_body body >>| fun x -> `Minimize x);
+        (fun body -> resume_ci_minimize_text_of_body body >>| fun x -> ResumeMinimize x);
+        (fun body -> ci_minimize_text_of_body body >>| fun x -> Minimize x);
         parse_run_ci;
         parse_merge;
         parse_bench
       ]
     in
     match parse () with
-    | Some (`ResumeMinimize (options, requests, bug_file)) ->
+    | Some (ResumeMinimize (options, requests, bug_file)) ->
       (fun () ->
         init_git_bare_repository ~bot_info
         >>= fun () ->
@@ -167,7 +181,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
       |> Lwt.async ;
       Server.respond_string ~status:`OK
         ~body:"Handling CI minimization resumption." ()
-    | Some (`Minimize (options, requests)) ->
+    | Some (Minimize (options, requests)) ->
       (fun () ->
          init_git_bare_repository ~bot_info
          >>= fun () ->
@@ -178,7 +192,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
                 ~comment_on_error:true ~options ~bug_file:None ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK ~body:"Handling CI minimization." ()
-    | Some (`RunCI full_ci) when
+    | Some (RunCI {full_ci}) when
         comment_info.issue.pull_request
         && String.equal comment_info.issue.issue.owner "rocq-prover"
         && String.equal comment_info.issue.issue.repo "rocq"
@@ -189,7 +203,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
         ~key ~app_id ~owner:comment_info.issue.issue.owner
         (Pr_sync.run_ci_action ~comment_info ?full_ci ~gitlab_mapping
            ~github_mapping () )
-    | Some `Merge when
+    | Some Merge when
         comment_info.issue.pull_request
         && String.equal comment_info.issue.issue.owner "rocq-prover"
         && String.equal comment_info.issue.issue.repo "rocq"
@@ -204,23 +218,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
       Server.respond_string ~status:`OK
         ~body:(f "Received a request to merge the PR.")
         ()
-    | Some `BenchNative when
-        comment_info.issue.pull_request
-        && String.equal comment_info.issue.issue.owner "rocq-prover"
-        && String.equal comment_info.issue.issue.repo "rocq"
-        && Option.is_some install_id ->
-      (fun () ->
-         Bot_components.Github_installations.action_as_github_app ~bot_info
-           ~key ~app_id ~owner:comment_info.issue.issue.owner
-           (fun ~bot_info ->
-              Bench.run_bench ~bot_info
-                ~key_value_pairs:[("coq_native", "yes")]
-                comment_info ) )
-      |> Lwt.async ;
-      Server.respond_string ~status:`OK
-        ~body:(f "Received a request to start the bench.")
-        ()
-    | Some (`Bench args) when
+    | Some (Bench args) when
             comment_info.issue.pull_request
             && String.equal comment_info.issue.issue.owner "rocq-prover"
             && String.equal comment_info.issue.issue.repo "rocq"

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -138,7 +138,7 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
         if
           string_match
             ~regexp:
-              ( f {|@%s:? [Bb]ench\( *$\| +\([^\n]+\) *\(\n\|$\)\)|}
+              ( f "@%s:? [Bb]ench\\( *$\\| +\\(.*\\(\n.+\\)*\\)\\(\n\n\\|$\\)\\)"
               @@ Str.quote github_bot_name )
             body
         then

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -66,7 +66,7 @@ let handle_push_event_for_repos ~bot_info ~key ~app_id ~install_id ~owner ~repo
       Server.respond_string ~status:`OK ~body:"Ignoring push event." ()
 
 module Commands = struct
-  type bench_args = (string * string option) list
+  type bench_args = Bench.args
 
   type t =
     | RunCI of {full_ci: bool option}
@@ -134,28 +134,6 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
         then Some Merge
         else None
       in
-      let parse_bench body =
-        if
-          string_match
-            ~regexp:
-              ( f "@%s:? [Bb]ench\\( *$\\| +\\(.*\\(\n.+\\)*\\)\\(\n\n\\|$\\)\\)"
-              @@ Str.quote github_bot_name )
-            body
-        then
-          match Str.matched_group 2 body with
-          | exception _ ->
-              Some (Bench [])
-          | args -> (
-            match parse_key_value_arguments args with
-            | Result.Ok args ->
-                Some (Bench args)
-            | Result.Error error ->
-                Some
-                  (ParseError
-                     (f "bench command could not parse key-value arguments: %s"
-                        error ) ) )
-        else None
-      in
       let parse () =
         let open Option in
         (* Since both ci minimization resumption and ci minimization will match the
@@ -168,7 +146,13 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
           ; (fun body -> ci_minimize_text_of_body body >>| fun x -> Minimize x)
           ; parse_run_ci
           ; parse_merge
-          ; parse_bench ]
+          ; (fun body ->
+              Bench.parse ~github_bot_name body
+              >>| function
+              | Result.Ok args ->
+                  Commands.Bench args
+              | Result.Error error ->
+                  ParseError error ) ]
       in
       match parse () with
       | Some (ResumeMinimize (options, requests, bug_file)) ->

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -90,125 +90,160 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
                 "https://github.com/rocq-community/run-coq-bug-minimizer/actions" ) )
       |> Lwt.async ;
       Server.respond_string ~status:`OK ~body:"Handling minimization." ()
-  | None -> (
-    (* Since both ci minimization resumption and ci
-       minimization will match the resumption string, and we
-       don't want to parse "resume" as an option, we test
-       resumption first *)
-    match resume_ci_minimize_text_of_body body with
-    | Some (options, requests, bug_file) ->
-        (fun () ->
-          init_git_bare_repository ~bot_info
-          >>= fun () ->
-          Bot_components.Github_installations.action_as_github_app ~bot_info
-            ~key ~app_id ~owner:comment_info.issue.issue.owner (fun ~bot_info ->
+  | None ->
+
+    let parse_run_ci body =
+      if string_match
+        ~regexp:
+          ( f "@%s:? [Rr]un \\(full\\|light\\|\\) ?[Cc][Ii]"
+            @@ Str.quote github_bot_name )
+        body
+      then
+        let full_ci =
+          match Str.matched_group 1 body with
+          | "full" -> Some true
+          | "light" -> Some false
+          | "" -> None
+          | _ -> failwith "Impossible group value."
+        in
+        Some (`RunCI full_ci)
+      else
+        None
+    in
+   let parse_merge body =
+     if string_match
+       ~regexp:(f "@%s:? [Mm]erge now" @@ Str.quote github_bot_name)
+       body
+     then
+       Some `Merge
+     else
+       None
+    in
+
+    let parse_bench_native body =
+      if
+        string_match
+          ~regexp:(f "@%s:? [Bb]ench native" @@ Str.quote github_bot_name)
+          body
+      then
+        Some `BenchNative
+      else
+        None
+    in
+
+    let parse_bench body =
+      if
+        string_match
+          ~regexp:(f "@%s:? [Bb]ench" @@ Str.quote github_bot_name)
+          body
+      then
+        Some `Bench
+      else
+        None
+    in
+    let parse () =
+      let open Option in
+      let rec first_success body fns =
+        match fns with
+        | fn :: fns ->
+          let res = fn body in
+          if Option.is_some res then res else first_success body fns
+        | [] -> None
+      in
+    (* Since both ci minimization resumption and ci minimization will match the
+       resumption string, and we don't want to parse "resume" as an option, we
+       test resumption first *)
+      first_success body [
+        (fun body -> resume_ci_minimize_text_of_body body >>| fun x -> `ResumeMinimize x);
+        (fun body -> ci_minimize_text_of_body body >>| fun x -> `Minimize x);
+        parse_run_ci;
+        parse_merge;
+        parse_bench_native;
+        parse_bench
+      ]
+    in
+    match parse () with
+    | Some (`ResumeMinimize (options, requests, bug_file)) ->
+      (fun () ->
+        init_git_bare_repository ~bot_info
+        >>= fun () ->
+        Bot_components.Github_installations.action_as_github_app ~bot_info
+          ~key ~app_id ~owner:comment_info.issue.issue.owner (fun ~bot_info ->
+            Minimization.ci_minimize ~bot_info ~comment_info ~requests
+              ~comment_on_error:true ~options ~bug_file:(Some bug_file) ) )
+      |> Lwt.async ;
+      Server.respond_string ~status:`OK
+        ~body:"Handling CI minimization resumption." ()
+    | Some (`Minimize (options, requests)) ->
+      (fun () ->
+         init_git_bare_repository ~bot_info
+         >>= fun () ->
+         Bot_components.Github_installations.action_as_github_app ~bot_info
+           ~key ~app_id ~owner:comment_info.issue.issue.owner
+           (fun ~bot_info ->
               Minimization.ci_minimize ~bot_info ~comment_info ~requests
-                ~comment_on_error:true ~options ~bug_file:(Some bug_file) ) )
-        |> Lwt.async ;
-        Server.respond_string ~status:`OK
-          ~body:"Handling CI minimization resumption." ()
-    | None -> (
-      match ci_minimize_text_of_body body with
-      | Some (options, requests) ->
-          (fun () ->
-            init_git_bare_repository ~bot_info
-            >>= fun () ->
-            Bot_components.Github_installations.action_as_github_app ~bot_info
-              ~key ~app_id ~owner:comment_info.issue.issue.owner
-              (fun ~bot_info ->
-                Minimization.ci_minimize ~bot_info ~comment_info ~requests
-                  ~comment_on_error:true ~options ~bug_file:None ) )
-          |> Lwt.async ;
-          Server.respond_string ~status:`OK ~body:"Handling CI minimization." ()
-      | None ->
-          if
-            string_match
-              ~regexp:
-                ( f "@%s:? [Rr]un \\(full\\|light\\|\\) ?[Cc][Ii]"
-                @@ Str.quote github_bot_name )
-              body
-            && comment_info.issue.pull_request
+                ~comment_on_error:true ~options ~bug_file:None ) )
+      |> Lwt.async ;
+      Server.respond_string ~status:`OK ~body:"Handling CI minimization." ()
+    | Some (`RunCI full_ci) when
+        comment_info.issue.pull_request
+        && String.equal comment_info.issue.issue.owner "rocq-prover"
+        && String.equal comment_info.issue.issue.repo "rocq"
+        && Option.is_some install_id ->
+      init_git_bare_repository ~bot_info
+      >>= fun () ->
+      Bot_components.Github_installations.action_as_github_app ~bot_info
+        ~key ~app_id ~owner:comment_info.issue.issue.owner
+        (Pr_sync.run_ci_action ~comment_info ?full_ci ~gitlab_mapping
+           ~github_mapping () )
+    | Some `Merge when
+        comment_info.issue.pull_request
+        && String.equal comment_info.issue.issue.owner "rocq-prover"
+        && String.equal comment_info.issue.issue.repo "rocq"
+        && Option.is_some install_id ->
+      (fun () ->
+         Bot_components.Github_installations.action_as_github_app ~bot_info
+           ~key ~app_id ~owner:comment_info.issue.issue.owner
+           (fun ~bot_info ->
+              GitHub_automation.merge_pull_request_action ~bot_info
+                comment_info ) )
+      |> Lwt.async ;
+      Server.respond_string ~status:`OK
+        ~body:(f "Received a request to merge the PR.")
+        ()
+    | Some `BenchNative when
+        comment_info.issue.pull_request
+        && String.equal comment_info.issue.issue.owner "rocq-prover"
+        && String.equal comment_info.issue.issue.repo "rocq"
+        && Option.is_some install_id ->
+      (fun () ->
+         Bot_components.Github_installations.action_as_github_app ~bot_info
+           ~key ~app_id ~owner:comment_info.issue.issue.owner
+           (fun ~bot_info ->
+              Bench.run_bench ~bot_info
+                ~key_value_pairs:[("coq_native", "yes")]
+                comment_info ) )
+      |> Lwt.async ;
+      Server.respond_string ~status:`OK
+        ~body:(f "Received a request to start the bench.")
+        ()
+    | Some `Bench when
+            comment_info.issue.pull_request
             && String.equal comment_info.issue.issue.owner "rocq-prover"
             && String.equal comment_info.issue.issue.repo "rocq"
-            && Option.is_some install_id
-          then
-            let full_ci =
-              match Str.matched_group 1 body with
-              | "full" ->
-                  Some true
-              | "light" ->
-                  Some false
-              | "" ->
-                  None
-              | _ ->
-                  failwith "Impossible group value."
-            in
-            init_git_bare_repository ~bot_info
-            >>= fun () ->
-            Bot_components.Github_installations.action_as_github_app ~bot_info
-              ~key ~app_id ~owner:comment_info.issue.issue.owner
-              (Pr_sync.run_ci_action ~comment_info ?full_ci ~gitlab_mapping
-                 ~github_mapping () )
-          else if
-            string_match
-              ~regexp:(f "@%s:? [Mm]erge now" @@ Str.quote github_bot_name)
-              body
-            && comment_info.issue.pull_request
-            && String.equal comment_info.issue.issue.owner "rocq-prover"
-            && String.equal comment_info.issue.issue.repo "rocq"
-            && Option.is_some install_id
-          then (
-            (fun () ->
-              Bot_components.Github_installations.action_as_github_app ~bot_info
-                ~key ~app_id ~owner:comment_info.issue.issue.owner
-                (fun ~bot_info ->
-                  GitHub_automation.merge_pull_request_action ~bot_info
-                    comment_info ) )
-            |> Lwt.async ;
-            Server.respond_string ~status:`OK
-              ~body:(f "Received a request to merge the PR.")
-              () )
-          else if
-            string_match
-              ~regexp:(f "@%s:? [Bb]ench native" @@ Str.quote github_bot_name)
-              body
-            && comment_info.issue.pull_request
-            && String.equal comment_info.issue.issue.owner "rocq-prover"
-            && String.equal comment_info.issue.issue.repo "rocq"
-            && Option.is_some install_id
-          then (
-            (fun () ->
-              Bot_components.Github_installations.action_as_github_app ~bot_info
-                ~key ~app_id ~owner:comment_info.issue.issue.owner
-                (fun ~bot_info ->
-                  Bench.run_bench ~bot_info
-                    ~key_value_pairs:[("coq_native", "yes")]
-                    comment_info ) )
-            |> Lwt.async ;
-            Server.respond_string ~status:`OK
-              ~body:(f "Received a request to start the bench.")
-              () )
-          else if
-            string_match
-              ~regexp:(f "@%s:? [Bb]ench" @@ Str.quote github_bot_name)
-              body
-            && comment_info.issue.pull_request
-            && String.equal comment_info.issue.issue.owner "rocq-prover"
-            && String.equal comment_info.issue.issue.repo "rocq"
-            && Option.is_some install_id
-          then (
-            (fun () ->
-              Bot_components.Github_installations.action_as_github_app ~bot_info
-                ~key ~app_id ~owner:comment_info.issue.issue.owner
-                (fun ~bot_info -> Bench.run_bench ~bot_info comment_info ) )
-            |> Lwt.async ;
-            Server.respond_string ~status:`OK
-              ~body:(f "Received a request to start the bench.")
-              () )
-          else
-            Server.respond_string ~status:`OK
-              ~body:(f "Unhandled comment: %s" body)
-              () ) )
+            && Option.is_some install_id ->
+      (fun () ->
+         Bot_components.Github_installations.action_as_github_app ~bot_info
+           ~key ~app_id ~owner:comment_info.issue.issue.owner
+           (fun ~bot_info -> Bench.run_bench ~bot_info comment_info ) )
+      |> Lwt.async ;
+      Server.respond_string ~status:`OK
+        ~body:(f "Received a request to start the bench.")
+        ()
+    | _ ->
+      Server.respond_string ~status:`OK
+        ~body:(f "Unhandled comment: %s" body)
+        ()
 
 let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
     ~gitlab_mapping ~github_mapping ~repo_config_table ~github_webhook_secret

--- a/tests/test_string_utils.ml
+++ b/tests/test_string_utils.ml
@@ -14,11 +14,6 @@ let test_strip_quoted_bot_name () =
   in
   (check string) "strip_quoted_bot_name" expected got
 
-let () =
-  run "String_utils tests"
-    [ ( "strip_quoted_bot_name"
-      , [test_case "quoted bot name" `Quick test_strip_quoted_bot_name] ) ]
-
 let tokens = Alcotest.list Alcotest.string
 
 let key_values =
@@ -56,7 +51,9 @@ let check_argument_error ~input ~expected () =
 
 let () =
   Alcotest.run "String_utils tests"
-    [ ( "split_on_unquoted_whitespace"
+    [ ( "strip_quoted_bot_name"
+      , [test_case "quoted bot name" `Quick test_strip_quoted_bot_name] )
+    ; ( "split_on_unquoted_whitespace"
       , [ ("empty input", `Quick, check_split ~input:"" ~expected:[])
         ; ( "unquoted arguments"
           , `Quick

--- a/tests/test_string_utils.ml
+++ b/tests/test_string_utils.ml
@@ -1,4 +1,6 @@
 open Alcotest
+open Base
+open String_utils
 
 let test_strip_quoted_bot_name () =
   let input =
@@ -16,3 +18,126 @@ let () =
   run "String_utils tests"
     [ ( "strip_quoted_bot_name"
       , [test_case "quoted bot name" `Quick test_strip_quoted_bot_name] ) ]
+
+let tokens = Alcotest.list Alcotest.string
+let key_values =
+  Alcotest.list (Alcotest.pair Alcotest.string (Alcotest.option Alcotest.string))
+
+let check_split ~input ~expected () =
+  match split_on_unquoted_whitespace input with
+  | Ok actual ->
+      Alcotest.check tokens input expected actual
+  | Error error ->
+      Alcotest.failf "expected %S to parse, but got: %s" input error
+
+let check_split_error ~input ~expected () =
+  match split_on_unquoted_whitespace input with
+  | Error actual ->
+      Alcotest.(check string) input expected actual
+  | Ok actual ->
+      Alcotest.failf "expected %S to fail, but got: [%s]" input
+        (String.concat ~sep:"; " actual)
+
+let check_arguments ~input ~expected () =
+  match parse_key_value_arguments input with
+  | Ok actual ->
+      Alcotest.check key_values input expected actual
+  | Error error ->
+      Alcotest.failf "expected %S to parse, but got: %s" input error
+
+let check_argument_error ~input ~expected () =
+  match parse_key_value_arguments input with
+  | Error actual ->
+      Alcotest.(check string) input expected actual
+  | Ok _ ->
+      Alcotest.failf "expected %S to fail" input
+
+let () =
+  Alcotest.run "String_utils tests"
+    [ ( "split_on_unquoted_whitespace"
+      , [ ( "empty input"
+          , `Quick
+          , check_split ~input:"" ~expected:[] )
+        ; ( "unquoted arguments"
+          , `Quick
+          , check_split ~input:"x=foo y=true" ~expected:["x=foo"; "y=true"] )
+        ; ( "double-quoted whitespace"
+          , `Quick
+          , check_split ~input:{|x="foo bar" y=true|}
+              ~expected:[{|x="foo bar"|}; "y=true"] )
+        ; ( "single-quoted whitespace"
+          , `Quick
+          , check_split ~input:"x='foo bar' y=true"
+              ~expected:["x='foo bar'"; "y=true"] )
+        ; ( "repeated whitespace"
+          , `Quick
+          , check_split ~input:"  x=foo\t\ty=true  "
+              ~expected:["x=foo"; "y=true"] )
+        ; ( "escaped quote"
+          , `Quick
+          , check_split ~input:{|x="foo \"bar\" baz" y=true|}
+              ~expected:[{|x="foo \"bar\" baz"|}; "y=true"] )
+        ; ( "escaped whitespace"
+          , `Quick
+          , check_split ~input:{|x=foo\ bar y=true|}
+              ~expected:[{|x=foo\ bar|}; "y=true"] )
+        ; ( "empty quoted arguments"
+          , `Quick
+          , check_split ~input:{|"" ''|} ~expected:[{|""|}; "''"] )
+        ; ( "unterminated double quote"
+          , `Quick
+          , check_split_error ~input:{|x="foo bar|}
+              ~expected:"unterminated \" quote" )
+        ; ( "trailing escape"
+          , `Quick
+          , check_split_error ~input:{|x=foo\|}
+              ~expected:"trailing escape character" ) ] )
+    ; ( "parse_key_value_arguments"
+      , [ ( "quoted value"
+          , `Quick
+          , check_arguments ~input:{|x="foo bar" y=true|}
+              ~expected:[("x", Some "foo bar"); ("y", Some "true")] )
+        ; ( "single-quoted value"
+          , `Quick
+          , check_arguments ~input:"x='foo bar' y=true"
+              ~expected:[("x", Some "foo bar"); ("y", Some "true")] )
+        ; ( "concatenated quoted text"
+          , `Quick
+          , check_arguments ~input:{|x=foo" bar" y='true'|}
+              ~expected:[("x", Some "foo bar"); ("y", Some "true")] )
+        ; ( "quoted whole argument"
+          , `Quick
+          , check_arguments ~input:{|"x=foo bar" y=true|}
+              ~expected:[("x", Some "foo bar"); ("y", Some "true")] )
+        ; ( "escaped whitespace"
+          , `Quick
+          , check_arguments ~input:{|x=foo\ bar y=true|}
+              ~expected:[("x", Some "foo bar"); ("y", Some "true")] )
+        ; ( "escaped quote"
+          , `Quick
+          , check_arguments ~input:{|x="foo \"bar\""|}
+              ~expected:[("x", Some {|foo "bar"|})] )
+        ; ( "literal nested quotes"
+          , `Quick
+          , check_arguments ~input:{|x='"foo bar"'|}
+              ~expected:[("x", Some {|"foo bar"|})] )
+        ; ( "explicit empty values"
+          , `Quick
+          , check_arguments ~input:{|x= y=""|}
+              ~expected:[("x", Some ""); ("y", Some "")] )
+        ; ( "additional equal signs"
+          , `Quick
+          , check_arguments ~input:"x=foo=bar"
+              ~expected:[("x", Some "foo=bar")] )
+        ; ( "missing value"
+          , `Quick
+          , check_arguments ~input:"x=foo missing"
+              ~expected:[("x", Some "foo"); ("missing", None)] )
+        ; ( "empty key"
+          , `Quick
+          , check_argument_error ~input:"=value"
+              ~expected:"argument \"=value\" has an empty key" )
+        ; ( "empty quoted key"
+          , `Quick
+          , check_argument_error ~input:{|""|}
+              ~expected:"argument \"\" has an empty key" ) ] ) ]

--- a/tests/test_string_utils.ml
+++ b/tests/test_string_utils.ml
@@ -20,8 +20,10 @@ let () =
       , [test_case "quoted bot name" `Quick test_strip_quoted_bot_name] ) ]
 
 let tokens = Alcotest.list Alcotest.string
+
 let key_values =
-  Alcotest.list (Alcotest.pair Alcotest.string (Alcotest.option Alcotest.string))
+  Alcotest.list
+    (Alcotest.pair Alcotest.string (Alcotest.option Alcotest.string))
 
 let check_split ~input ~expected () =
   match split_on_unquoted_whitespace input with
@@ -55,9 +57,7 @@ let check_argument_error ~input ~expected () =
 let () =
   Alcotest.run "String_utils tests"
     [ ( "split_on_unquoted_whitespace"
-      , [ ( "empty input"
-          , `Quick
-          , check_split ~input:"" ~expected:[] )
+      , [ ("empty input", `Quick, check_split ~input:"" ~expected:[])
         ; ( "unquoted arguments"
           , `Quick
           , check_split ~input:"x=foo y=true" ~expected:["x=foo"; "y=true"] )
@@ -127,8 +127,8 @@ let () =
               ~expected:[("x", Some ""); ("y", Some "")] )
         ; ( "additional equal signs"
           , `Quick
-          , check_arguments ~input:"x=foo=bar"
-              ~expected:[("x", Some "foo=bar")] )
+          , check_arguments ~input:"x=foo=bar" ~expected:[("x", Some "foo=bar")]
+          )
         ; ( "missing value"
           , `Quick
           , check_arguments ~input:"x=foo missing"
@@ -143,7 +143,7 @@ let () =
               ~expected:"argument \"\" has an empty key" )
         ; ( "coq_opam_packages"
           , `Quick
-          , check_arguments
-              ~input:{|coq_opam_packages="a b c" coq_native|}
-              ~expected:[("coq_opam_packages", Some "a b c"); ("coq_native", None)])
-        ] ) ]
+          , check_arguments ~input:{|coq_opam_packages="a b c" coq_native|}
+              ~expected:
+                [("coq_opam_packages", Some "a b c"); ("coq_native", None)] ) ]
+      ) ]

--- a/tests/test_string_utils.ml
+++ b/tests/test_string_utils.ml
@@ -140,4 +140,10 @@ let () =
         ; ( "empty quoted key"
           , `Quick
           , check_argument_error ~input:{|""|}
-              ~expected:"argument \"\" has an empty key" ) ] ) ]
+              ~expected:"argument \"\" has an empty key" )
+        ; ( "coq_opam_packages"
+          , `Quick
+          , check_arguments
+              ~input:{|coq_opam_packages="a b c" coq_native|}
+              ~expected:[("coq_opam_packages", Some "a b c"); ("coq_native", None)])
+        ] ) ]


### PR DESCRIPTION
This *should* allow writing commands like `bench coq_opam_packages="a b c"`, eliminating the need to push temporary commits for bench configuration. The native bench branch in the parser is now gone as that can be written as `bench coq_native` now.

The commits are hopefully self-explanatory. I took the liberty to restructure the comment parsing code (commit #1) because the old code was quite confusing to me and the control flow seemed odd. We now commit to one command and if argument parsing fails or permissions are missing, we go straight to the error case.

The string parsing and the test cases are generated by LLMs. The rest of the code is handwritten.

The PR is a draft for three reasons:
- ~~Passing arbitrary variables to the bench job could be a security concern. I don't know the bench code well enough to say. We might want a whitelist?~~ (EDIT: No change in security risk compared to setting arguments via new commits that change bench.sh)
- I have no idea how to run all tests in the repo. A bunch of dependencies are not recorded (`alcotest`, `ppx_expect`) and adding them manually still brings me to a point where some kind of token is required. Disabling all that still produces failures in inline tests that I do not understand.
- ~~The bench command is entirely undocumented and with it being a bit more complex now I think we need documentation.~~ (EDIT: I found the actual place where the bench command is documented (https://github.com/rocq-prover/rocq/wiki/Benchmarking) and since it is not in this repo, it does not affect the actual code changes.)