### PR TITLE
Fix `dune runtest` by moving utils expect tests to Alcotest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Check formatting and run tests
-        run: nix-shell --run "dune build @fmt && dune build @tests/runtest"
+        run: nix-shell --run "dune build @fmt && dune build @runtest"

--- a/bot-components/dune
+++ b/bot-components/dune
@@ -7,7 +7,6 @@
  (modules_without_implementation GitHub_types GitLab_types)
  (libraries base camlzip cohttp-lwt-unix eqaf ohex mirage-crypto stdio str
    x509 yojson ISO8601 digestif toml)
- (inline_tests)
  (preprocess
   (per_module
    ((pps graphql_ppx -- -native -schema
@@ -15,10 +14,7 @@
     GitHub_GraphQL)
    ((pps graphql_ppx -- -native -schema
       bot-components/gitlab/gitlab-schema.json)
-    GitLab_GraphQL)
-   ((pps ppx_expect)
-    String_utils
-    Git_utils)))
+    GitLab_GraphQL)))
  (preprocessor_deps
   (file github/github-schema.json)
   (file gitlab/gitlab-schema.json)))

--- a/bot-components/utils/Git_utils.ml
+++ b/bot-components/utils/Git_utils.ml
@@ -109,37 +109,6 @@ let parse_gitlab_repo_url ~http_repo_url =
     Result.Ok
       (Str.matched_group 1 http_repo_url, Str.matched_group 2 http_repo_url)
 
-let parse_gitlab_repo_url_and_print ~http_repo_url =
-  match parse_gitlab_repo_url ~http_repo_url with
-  | Ok (gitlab_domain, gitlab_repo_full_name) ->
-      Stdio.printf "GitLab domain: \"%s\"\n" gitlab_domain ;
-      Stdio.printf "GitLab repository full name: \"%s\"\n" gitlab_repo_full_name
-  | Error msg ->
-      Stdio.print_endline msg
-
-let%expect_test "http_repo_url_parsing_coq" =
-  parse_gitlab_repo_url_and_print ~http_repo_url:"https://gitlab.com/coq/coq" ;
-  [%expect
-    {|
-   GitLab domain: "gitlab.com"
-   GitLab repository full name: "coq/coq" |}]
-
-let%expect_test "http_repo_url_parsing_mathcomp" =
-  parse_gitlab_repo_url_and_print
-    ~http_repo_url:"https://gitlab.inria.fr/math-comp/math-comp" ;
-  [%expect
-    {|
-  GitLab domain: "gitlab.inria.fr"
-  GitLab repository full name: "math-comp/math-comp" |}]
-
-let%expect_test "http_repo_url_parsing_example_from_gitlab_docs" =
-  parse_gitlab_repo_url_and_print
-    ~http_repo_url:"https://gitlab.example.com/gitlab-org/gitlab-test" ;
-  [%expect
-    {|
-  GitLab domain: "gitlab.example.com"
-  GitLab repository full name: "gitlab-org/gitlab-test" |}]
-
 let init_git_bare_repository ~bot_info =
   let* () = Lwt_io.printl "Initializing repository..." in
   let github_token = Bot_info.github_token bot_info in

--- a/bot-components/utils/String_utils.ml
+++ b/bot-components/utils/String_utils.ml
@@ -94,13 +94,6 @@ let strip_quoted_bot_name ~github_bot_name body =
     (Printf.sprintf "@\\1%s " (Str.quote github_bot_name))
     body
 
-let%expect_test "strip_quoted_bot_name" =
-  Stdio.printf "%s\n"
-    (strip_quoted_bot_name ~github_bot_name:"coqbot"
-       {|>this didn't produce a pipeline for some reason\r\n\r\nI think that this is normal. @herbelin was maybe expecting that adding the `request: full CI` label would trigger a new run immediately, but the semantics is that this label will produce such a full CI run at the next update (next push) of this PR. Cf. the [documentation](https://github.com/coq/coq/blob/master/CONTRIBUTING.md#understanding-automatic-feedback):\r\n\r\n>you can request a full run of the CI by putting the `request: full CI` label before pushing to your PR branch, or by commenting `@coqbot: run full CI` after having pushed. |} ) ;
-  [%expect
-    {| >this didn't produce a pipeline for some reason\r\n\r\nI think that this is normal. @herbelin was maybe expecting that adding the `request: full CI` label would trigger a new run immediately, but the semantics is that this label will produce such a full CI run at the next update (next push) of this PR. Cf. the [documentation](https://github.com/coq/coq/blob/master/CONTRIBUTING.md#understanding-automatic-feedback):\r\n\r\n>you can request a full run of the CI by putting the `request: full CI` label before pushing to your PR branch, or by commenting @`coqbot run full CI` after having pushed. |}]
-
 let clean_gitlab_trace trace =
   trace
   |> Str.global_replace (Str.regexp "\027\\[[0-9;]*m") ""

--- a/tests/dune
+++ b/tests/dune
@@ -33,3 +33,13 @@
  (name test_minimize_parser)
  (modules test_minimize_parser)
  (libraries alcotest bot-components base))
+
+(test
+ (name test_git_utils)
+ (modules test_git_utils)
+ (libraries alcotest bot-components base))
+
+(test
+ (name test_string_utils)
+ (modules test_string_utils)
+ (libraries alcotest bot-components base))

--- a/tests/test_git_utils.ml
+++ b/tests/test_git_utils.ml
@@ -1,0 +1,22 @@
+open Base
+open Alcotest
+
+let test_parse_gitlab_repo_url () =
+  let check url domain full_name =
+    match Git_utils.parse_gitlab_repo_url ~http_repo_url:url with
+    | Ok (d, n) ->
+        (check string) "domain" domain d ;
+        (check string) "full_name" full_name n
+    | Error e ->
+        fail e
+  in
+  check "https://gitlab.com/coq/coq" "gitlab.com" "coq/coq" ;
+  check "https://gitlab.inria.fr/math-comp/math-comp" "gitlab.inria.fr"
+    "math-comp/math-comp" ;
+  check "https://gitlab.example.com/gitlab-org/gitlab-test" "gitlab.example.com"
+    "gitlab-org/gitlab-test"
+
+let () =
+  run "Git_utils tests"
+    [ ( "parse_gitlab_repo_url"
+      , [test_case "http urls" `Quick test_parse_gitlab_repo_url] ) ]

--- a/tests/test_string_utils.ml
+++ b/tests/test_string_utils.ml
@@ -1,0 +1,18 @@
+open Alcotest
+
+let test_strip_quoted_bot_name () =
+  let input =
+    {|>this didn't produce a pipeline for some reason\r\n\r\nI think that this is normal. @herbelin was maybe expecting that adding the `request: full CI` label would trigger a new run immediately, but the semantics is that this label will produce such a full CI run at the next update (next push) of this PR. Cf. the [documentation](https://github.com/coq/coq/blob/master/CONTRIBUTING.md#understanding-automatic-feedback):\r\n\r\n>you can request a full run of the CI by putting the `request: full CI` label before pushing to your PR branch, or by commenting `@coqbot: run full CI` after having pushed. |}
+  in
+  let expected =
+    {|>this didn't produce a pipeline for some reason\r\n\r\nI think that this is normal. @herbelin was maybe expecting that adding the `request: full CI` label would trigger a new run immediately, but the semantics is that this label will produce such a full CI run at the next update (next push) of this PR. Cf. the [documentation](https://github.com/coq/coq/blob/master/CONTRIBUTING.md#understanding-automatic-feedback):\r\n\r\n>you can request a full run of the CI by putting the `request: full CI` label before pushing to your PR branch, or by commenting @`coqbot run full CI` after having pushed. |}
+  in
+  let got =
+    String_utils.strip_quoted_bot_name ~github_bot_name:"coqbot" input
+  in
+  (check string) "strip_quoted_bot_name" expected got
+
+let () =
+  run "String_utils tests"
+    [ ( "strip_quoted_bot_name"
+      , [test_case "quoted bot name" `Quick test_strip_quoted_bot_name] ) ]


### PR DESCRIPTION
- Remove `ppx_expect` inline tests from `Git_utils` / `String_utils` (they crash under `include_subdirs` when writing corrected files).
- Drop `inline_tests` / `ppx_expect` from `bot-components`.
- Re-add the same coverage as Alcotest in `tests/test_git_utils.ml` and `tests/test_string_utils.ml`.
- Change CI to run full `dune build @runtest` instead of `dune build @tests/runtest`

Reason:
`dune runtest` failed with `Sys_error` looking for `Git_utils.ml` / `String_utils.ml` at the library root instead of` utils/`. 
CI only ran `@tests/runtest`, so this was easy to miss.

