### PR TITLE
Backport and project card logic

### DIFF
--- a/bot-components/github/GitHub_automation.ml
+++ b/bot-components/github/GitHub_automation.ml
@@ -253,10 +253,10 @@ let project_action ~bot_info ~pr_id ~backport_to () =
         | Error err ->
             Lwt_io.printlf "Error while obtaining milestone ID: %s" err ) )
 
-let add_to_column ~bot_info ~backport_to id option =
+let add_to_column ~bot_info ~organization ~project ~backport_to id option =
   let field = backport_to ^ " status" in
-  GitHub_queries.get_project_field_values ~bot_info ~organization:"rocq-prover"
-    ~project:11 ~field ~options:[|option|]
+  GitHub_queries.get_project_field_values ~bot_info ~organization ~project
+    ~field ~options:[|option|]
   >>= fun project_info ->
   ( match project_info with
     | Ok (project_id, Some (field_id, [(option', field_value_id)]))

--- a/bot-components/github/GitHub_automation.ml
+++ b/bot-components/github/GitHub_automation.ml
@@ -216,43 +216,6 @@ let rec adjust_milestone ~bot_info ~issue ~sleep_time =
   | Error err ->
       Lwt_io.print (f "Error: %s\n" err)
 
-let project_action ~bot_info ~pr_id ~backport_to () =
-  GitHub_queries.get_pull_request_milestone ~bot_info ~pr_id
-  >>= function
-  | Error err ->
-      Lwt_io.printf "Error: %s\n" err
-  | Ok backport_info -> (
-    match
-      List.find_map backport_info
-        ~f:(fun {backport_to= backport_to'; rejected_milestone} ->
-          if String.equal backport_to backport_to' then Some rejected_milestone
-          else None )
-    with
-    | None ->
-        Lwt_io.printf
-          "PR already not in milestone with backporting info for branch %s.\n"
-          backport_to
-    | Some rejected_milestone -> (
-        Lwt_io.printf
-          "PR is in milestone for which backporting to %s was rejected.\n\
-           Change of milestone requested.\n"
-          backport_to
-        >>= fun () ->
-        GitHub_queries.get_milestone_id ~bot_info ~owner:"rocq-prover"
-          ~repo:"rocq" ~number:rejected_milestone
-        >>= function
-        | Ok milestone ->
-            GitHub_mutations.update_milestone_pull_request ~bot_info ~pr_id
-              ~milestone
-            <&> ( GitHub_mutations.post_comment ~bot_info ~id:pr_id
-                    ~message:
-                      "This PR was postponed. Please update accordingly the \
-                       milestone of any issue that this fixes as this cannot \
-                       be done automatically."
-                >>= Utils.report_on_posting_comment )
-        | Error err ->
-            Lwt_io.printlf "Error while obtaining milestone ID: %s" err ) )
-
 let add_to_column ~bot_info ~organization ~project ~backport_to id option =
   let field = backport_to ^ " status" in
   GitHub_queries.get_project_field_values ~bot_info ~organization ~project

--- a/bot-components/github/GitHub_automation.mli
+++ b/bot-components/github/GitHub_automation.mli
@@ -7,13 +7,6 @@ val adjust_milestone :
   -> sleep_time:float
   -> unit Lwt.t
 
-val project_action :
-     bot_info:Bot_info.t
-  -> pr_id:GitHub_ID.t
-  -> backport_to:string
-  -> unit
-  -> unit Lwt.t
-
 val add_to_column :
      bot_info:Bot_info.t
   -> organization:string

--- a/bot-components/github/GitHub_automation.mli
+++ b/bot-components/github/GitHub_automation.mli
@@ -16,6 +16,8 @@ val project_action :
 
 val add_to_column :
      bot_info:Bot_info.t
+  -> organization:string
+  -> project:int
   -> backport_to:string
   -> [< `Card_ID of GitHub_ID.t | `PR_ID of GitHub_ID.t]
   -> string

--- a/src/actions/backport.ml
+++ b/src/actions/backport.ml
@@ -96,3 +96,43 @@ let push_action ~bot_info ~(repo_config : Repo_config.t) ~base_ref ~commits_msg
         else Lwt.return_unit
       in
       Lwt_list.iter_s commit_action commits_msg
+
+let project_action ~bot_info ~(repo_config : Repo_config.t) ~pr_id ~backport_to
+    () =
+  let owner = repo_config.github_owner in
+  let repo = repo_config.github_repo in
+  GitHub_queries.get_pull_request_milestone ~bot_info ~pr_id
+  >>= function
+  | Error err ->
+      Lwt_io.printf "Error: %s\n" err
+  | Ok backport_info -> (
+    match
+      List.find_map backport_info
+        ~f:(fun {backport_to= backport_to'; rejected_milestone} ->
+          if String.equal backport_to backport_to' then Some rejected_milestone
+          else None )
+    with
+    | None ->
+        Lwt_io.printf
+          "PR already not in milestone with backporting info for branch %s.\n"
+          backport_to
+    | Some rejected_milestone -> (
+        Lwt_io.printf
+          "PR is in milestone for which backporting to %s was rejected.\n\
+           Change of milestone requested.\n"
+          backport_to
+        >>= fun () ->
+        GitHub_queries.get_milestone_id ~bot_info ~owner ~repo
+          ~number:rejected_milestone
+        >>= function
+        | Ok milestone ->
+            GitHub_mutations.update_milestone_pull_request ~bot_info ~pr_id
+              ~milestone
+            <&> ( GitHub_mutations.post_comment ~bot_info ~id:pr_id
+                    ~message:
+                      "This PR was postponed. Please update accordingly the \
+                       milestone of any issue that this fixes as this cannot \
+                       be done automatically."
+                >>= Utils.report_on_posting_comment )
+        | Error err ->
+            Lwt_io.printlf "Error while obtaining milestone ID: %s" err ) )

--- a/src/actions/backport.ml
+++ b/src/actions/backport.ml
@@ -4,77 +4,95 @@ open Bot_components.GitHub_types
 open Lwt.Infix
 open Lwt.Syntax
 
-let rocq_push_action ~bot_info ~base_ref ~commits_msg =
-  let* () = Lwt_io.printl "Merge and backport commit messages:" in
-  let commit_action commit_msg =
-    if
-      String_utils.string_match
-        ~regexp:"^Merge \\(PR\\|pull request\\) #\\([0-9]*\\)" commit_msg
-    then
-      let pr_number = Str.matched_group 2 commit_msg |> Int.of_string in
-      Lwt_io.printf "%s\nPR #%d was merged.\n" commit_msg pr_number
-      >>= fun () ->
-      GitHub_queries.get_pull_request_id_and_milestone ~bot_info
-        ~owner:"rocq-prover" ~repo:"rocq" ~number:pr_number
-      >>= fun pr_info ->
-      match pr_info with
-      | Ok (pr_id, backport_info) ->
-          backport_info
-          |> Lwt_list.iter_p (fun {backport_to} ->
-              if "refs/heads/" ^ backport_to |> String.equal base_ref then
-                Lwt_io.printf
-                  "PR was merged into the backporting branch directly.\n"
-                >>= fun () ->
-                GitHub_automation.add_to_column ~bot_info ~backport_to
-                  (`PR_ID pr_id) "Shipped"
-              else if String.equal base_ref "refs/heads/master" then
-                (* For now, we hard code that PRs are only backported
+let push_action ~bot_info ~(repo_config : Repo_config.t) ~base_ref ~commits_msg
+    =
+  match repo_config.backporting.github_project_number with
+  | None ->
+      Lwt_io.printl "Backporting disabled: no github_project_number configured."
+  | Some project_number ->
+      let owner = repo_config.github_owner in
+      let repo = repo_config.github_repo in
+      let organization = Repo_config.project_organization repo_config in
+      let* () = Lwt_io.printl "Merge and backport commit messages:" in
+      let commit_action commit_msg =
+        if
+          String_utils.string_match
+            ~regexp:"^Merge \\(PR\\|pull request\\) #\\([0-9]*\\)" commit_msg
+        then
+          let pr_number = Str.matched_group 2 commit_msg |> Int.of_string in
+          Lwt_io.printf "%s\nPR #%d was merged.\n" commit_msg pr_number
+          >>= fun () ->
+          GitHub_queries.get_pull_request_id_and_milestone ~bot_info ~owner
+            ~repo ~number:pr_number
+          >>= fun pr_info ->
+          match pr_info with
+          | Ok (pr_id, backport_info) ->
+              backport_info
+              |> Lwt_list.iter_p (fun {backport_to} ->
+                  if "refs/heads/" ^ backport_to |> String.equal base_ref then
+                    Lwt_io.printf
+                      "PR was merged into the backporting branch directly.\n"
+                    >>= fun () ->
+                    GitHub_automation.add_to_column ~bot_info ~organization
+                      ~project:project_number ~backport_to (`PR_ID pr_id)
+                      "Shipped"
+                  else if String.equal base_ref "refs/heads/master" then
+                    (* For now, we hard code that PRs are only backported
                       from master.  In the future, we could make this
                       configurable in the milestone description or in
                       some configuration file. *)
-                Lwt_io.printf "Backporting to %s was requested.\n" backport_to
-                >>= fun () ->
-                GitHub_automation.add_to_column ~bot_info ~backport_to
-                  (`PR_ID pr_id) "Request inclusion"
-              else
-                Lwt_io.printf
-                  "PR was merged into a branch that is not the backporting \
-                   branch nor the master branch.\n" )
-      | Error err ->
-          Lwt_io.printf "Error: %s\n" err
-    else if
-      String_utils.string_match ~regexp:"^Backport PR #\\([0-9]*\\):" commit_msg
-    then
-      let pr_number = Str.matched_group 1 commit_msg |> Int.of_string in
-      Lwt_io.printf "%s\nPR #%d was backported.\n" commit_msg pr_number
-      >>= fun () ->
-      GitHub_queries.get_pull_request_cards ~bot_info ~owner:"rocq-prover"
-        ~repo:"rocq" ~number:pr_number
-      >>= function
-      | Ok items -> (
-          let backport_to =
-            String.chop_prefix_if_exists ~prefix:"refs/heads/" base_ref
-          in
-          let card_id =
-            items |> List.find_map ~f:(function id, 11 -> Some id | _ -> None)
-          in
-          match card_id with
-          | Some card_id ->
-              Lwt_io.printlf
-                "Pull request rocq-prover/rocq#%d found in project 11. \
-                 Updating its fields."
-                pr_number
-              >>= fun () ->
-              GitHub_automation.add_to_column ~bot_info ~backport_to
-                (`Card_ID card_id) "Shipped"
-          | None ->
-              (* We could do something in this case, like post a comment to
+                    Lwt_io.printf "Backporting to %s was requested.\n"
+                      backport_to
+                    >>= fun () ->
+                    GitHub_automation.add_to_column ~bot_info ~organization
+                      ~project:project_number ~backport_to (`PR_ID pr_id)
+                      "Request inclusion"
+                  else
+                    Lwt_io.printf
+                      "PR was merged into a branch that is not the backporting \
+                       branch nor the master branch.\n" )
+          | Error err ->
+              Lwt_io.printf "Error: %s\n" err
+        else if
+          String_utils.string_match ~regexp:"^Backport PR #\\([0-9]*\\):"
+            commit_msg
+        then
+          let pr_number = Str.matched_group 1 commit_msg |> Int.of_string in
+          Lwt_io.printf "%s\nPR #%d was backported.\n" commit_msg pr_number
+          >>= fun () ->
+          GitHub_queries.get_pull_request_cards ~bot_info ~owner ~repo
+            ~number:pr_number
+          >>= function
+          | Ok items -> (
+              let backport_to =
+                String.chop_prefix_if_exists ~prefix:"refs/heads/" base_ref
+              in
+              let card_id =
+                items
+                |> List.find_map ~f:(function
+                  | id, pn when Int.equal pn project_number ->
+                      Some id
+                  | _ ->
+                      None )
+              in
+              match card_id with
+              | Some card_id ->
+                  Lwt_io.printlf
+                    "Pull request %s/%s#%d found in project %d. Updating its \
+                     fields."
+                    owner repo pr_number project_number
+                  >>= fun () ->
+                  GitHub_automation.add_to_column ~bot_info ~organization
+                    ~project:project_number ~backport_to (`Card_ID card_id)
+                    "Shipped"
+              | None ->
+                  (* We could do something in this case, like post a comment to
                  the PR and add the PR to the project. *)
-              Lwt_io.printlf
-                "Pull request rocq-prover/rocq#%d not found in project 11."
-                pr_number )
-      | Error e ->
-          Lwt_io.printf "%s\n" e
-    else Lwt.return_unit
-  in
-  Lwt_list.iter_s commit_action commits_msg
+                  Lwt_io.printlf
+                    "Pull request %s/%s#%d not found in project %d." owner repo
+                    pr_number project_number )
+          | Error e ->
+              Lwt_io.printf "%s\n" e
+        else Lwt.return_unit
+      in
+      Lwt_list.iter_s commit_action commits_msg

--- a/src/actions/backport.mli
+++ b/src/actions/backport.mli
@@ -4,3 +4,11 @@ val push_action :
   -> base_ref:string
   -> commits_msg:string list
   -> unit Lwt.t
+
+val project_action :
+     bot_info:Bot_info.t
+  -> repo_config:Repo_config.t
+  -> pr_id:GitHub_ID.t
+  -> backport_to:string
+  -> unit
+  -> unit Lwt.t

--- a/src/actions/backport.mli
+++ b/src/actions/backport.mli
@@ -1,5 +1,6 @@
-val rocq_push_action :
+val push_action :
      bot_info:Bot_components.Bot_info.t
+  -> repo_config:Repo_config.t
   -> base_ref:string
   -> commits_msg:string list
   -> unit Lwt.t

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -52,9 +52,10 @@ let callback _conn req body =
         ~gitlab_webhook_secret ~headers:(Request.headers req) ~body
   | "/push" | "/pull_request" (* legacy endpoints *) | "/github" ->
       Github.handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
-        ~gitlab_mapping ~github_mapping ~github_webhook_secret
-        ~headers:(Request.headers req) ~body ~minimize_text_of_body
-        ~ci_minimize_text_of_body ~resume_ci_minimize_text_of_body
+        ~gitlab_mapping ~repo_config_table ~github_mapping
+        ~github_webhook_secret ~headers:(Request.headers req) ~body
+        ~minimize_text_of_body ~ci_minimize_text_of_body
+        ~resume_ci_minimize_text_of_body
   | "/coq-bug-minimizer" | "/ci-minimization" | "/resume-ci-minimization" ->
       Minimizer.handle_minimizer_webhook ~bot_info ~key ~app_id ~endpoint:path
         ~body

--- a/src/config/repo_config.ml
+++ b/src/config/repo_config.ml
@@ -108,3 +108,20 @@ let find_by_github ~owner ~repo tbl =
         String.equal cfg.github_owner owner && String.equal cfg.github_repo repo
       then Some cfg
       else None )
+
+let project_organization cfg =
+  Option.value cfg.org_name ~default:cfg.github_owner
+
+let backport_enabled cfg = Option.is_some cfg.backporting.github_project_number
+
+let find_by_backport_project ~install_id ~project_number tbl =
+  Hashtbl.to_alist tbl
+  |> List.find_map ~f:(fun (_key, cfg) ->
+      match
+        (cfg.github_installation_id, cfg.backporting.github_project_number)
+      with
+      | Some iid, Some pn
+        when Int.equal iid install_id && Int.equal pn project_number ->
+          Some cfg
+      | _ ->
+          None )

--- a/src/config/repo_config.mli
+++ b/src/config/repo_config.mli
@@ -25,3 +25,10 @@ val make_repo_config_table : Toml.Types.table -> (string, t) Base.Hashtbl.t
 
 val find_by_github :
   owner:string -> repo:string -> (string, t) Base.Hashtbl.t -> t option
+
+val project_organization : t -> string
+
+val backport_enabled : t -> bool
+
+val find_by_backport_project :
+  install_id:int -> project_number:int -> (string, t) Base.Hashtbl.t -> t option

--- a/src/webhooks/dune
+++ b/src/webhooks/dune
@@ -2,6 +2,6 @@
  (name webhooks)
  (public_name coq-bot.webhooks)
  (libraries base bot-components cohttp-lwt-unix coq-bot.actions coq-bot.ci
-   coq-bot.utils)
+   coq-bot.utils coq-bot.config)
  (wrapped false)
  (modules github gitlab minimizer scheduled))

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -308,8 +308,12 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
     with
     | None ->
         Server.respond_string ~status:`OK
-          ~body:"Unsupported pull request card edition." ()
+          ~body:
+            "Pull request card edition ignored: backporting project not \
+             configured."
+          ()
     | Some repo_config ->
+        (* Field matches "<branch> status" (checked above); drop " status". *)
         let backport_to = String.drop_suffix field 7 in
         (fun () ->
           Bot_components.Github_installations

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -211,8 +211,8 @@ let handle_comment_created ~bot_info ~key ~app_id ~github_bot_name
               () ) )
 
 let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
-    ~gitlab_mapping ~github_mapping ~github_webhook_secret ~headers ~body
-    ~minimize_text_of_body ~ci_minimize_text_of_body
+    ~gitlab_mapping ~github_mapping ~repo_config_table ~github_webhook_secret
+    ~headers ~body ~minimize_text_of_body ~ci_minimize_text_of_body
     ~resume_ci_minimize_text_of_body =
   body
   >>= fun body ->
@@ -228,9 +228,20 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
       (fun () ->
         init_git_bare_repository ~bot_info
         >>= fun () ->
-        Bot_components.Github_installations.action_as_github_app_from_install_id
-          ~bot_info ~key ~app_id ~install_id
-          (Backport.rocq_push_action ~base_ref ~commits_msg)
+        let backport =
+          match
+            Repo_config.find_by_github ~owner:"rocq-prover" ~repo:"rocq"
+              repo_config_table
+          with
+          | Some cfg when Repo_config.backport_enabled cfg ->
+              Bot_components.Github_installations
+              .action_as_github_app_from_install_id ~bot_info ~key ~app_id
+                ~install_id
+                (Backport.push_action ~repo_config:cfg ~base_ref ~commits_msg)
+          | _ ->
+              Lwt.return_unit
+        in
+        backport
         <&> Bot_components.Github_installations
             .action_as_github_app_from_install_id ~bot_info ~key ~app_id
               ~install_id

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -294,14 +294,17 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
              issue.repo issue.number )
         ()
   | Ok
-      ( Some (1062161 as install_id) (* Rocq's installation number *)
+      ( Some install_id
       , PullRequestCardEdited
-          { project_number= 11 (* Rocq's backporting project number *)
+          { project_number
           ; pr_id
           ; field
           ; old_value= Some "Request inclusion"
           ; new_value= Some "Rejected" } )
-    when String.is_suffix ~suffix:" status" field ->
+    when String.is_suffix ~suffix:" status" field
+         && Option.is_some
+              (Repo_config.find_by_backport_project ~install_id ~project_number
+                 repo_config_table ) ->
       let backport_to = String.drop_suffix field 7 in
       (fun () ->
         Bot_components.Github_installations.action_as_github_app_from_install_id

--- a/src/webhooks/github.ml
+++ b/src/webhooks/github.ml
@@ -301,23 +301,30 @@ let handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
           ; field
           ; old_value= Some "Request inclusion"
           ; new_value= Some "Rejected" } )
-    when String.is_suffix ~suffix:" status" field
-         && Option.is_some
-              (Repo_config.find_by_backport_project ~install_id ~project_number
-                 repo_config_table ) ->
-      let backport_to = String.drop_suffix field 7 in
-      (fun () ->
-        Bot_components.Github_installations.action_as_github_app_from_install_id
-          ~bot_info ~key ~app_id ~install_id (fun ~bot_info ->
-            GitHub_automation.project_action ~bot_info ~pr_id ~backport_to () ) )
-      |> Lwt.async ;
-      Server.respond_string ~status:`OK
-        ~body:
-          (f
-             "PR proposed for backporting was rejected from inclusion in %s. \
-              Updating the milestone."
-             backport_to )
-        ()
+    when String.is_suffix ~suffix:" status" field -> (
+    match
+      Repo_config.find_by_backport_project ~install_id ~project_number
+        repo_config_table
+    with
+    | None ->
+        Server.respond_string ~status:`OK
+          ~body:"Unsupported pull request card edition." ()
+    | Some repo_config ->
+        let backport_to = String.drop_suffix field 7 in
+        (fun () ->
+          Bot_components.Github_installations
+          .action_as_github_app_from_install_id ~bot_info ~key ~app_id
+            ~install_id (fun ~bot_info ->
+              Backport.project_action ~bot_info ~repo_config ~pr_id ~backport_to
+                () ) )
+        |> Lwt.async ;
+        Server.respond_string ~status:`OK
+          ~body:
+            (f
+               "PR proposed for backporting was rejected from inclusion in %s. \
+                Updating the milestone."
+               backport_to )
+          () )
   | Ok (_, PullRequestCardEdited _) ->
       Server.respond_string ~status:`OK
         ~body:"Unsupported pull request card edition." ()

--- a/src/webhooks/github.mli
+++ b/src/webhooks/github.mli
@@ -7,6 +7,7 @@ val handle_github_webhook :
   -> github_bot_name:string
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
   -> github_mapping:(string, string * string) Base.Hashtbl.t
+  -> repo_config_table:(string, Repo_config.t) Base.Hashtbl.t
   -> github_webhook_secret:string
   -> headers:Cohttp.Header.t
   -> body:string Lwt.t

--- a/tests/test_repo_config.ml
+++ b/tests/test_repo_config.ml
@@ -81,6 +81,48 @@ let test_find_miss () =
     (Option.is_none
        (Repo_config.find_by_github ~owner:"other" ~repo:"repo" tbl) )
 
+let test_backport_enabled () =
+  let with_project =
+    parse
+      {|
+    [repositories.rocq]
+    github = "rocq-prover/rocq"
+    github_installation_id = 102161
+    org_name = "rocq-prover"
+
+    [repositories.rocq.backporting]
+    github_project_number = 11
+    |}
+  in
+  let without_project =
+    parse {|
+    [repositories.demo]
+    github = "my-org/my-repo"
+    |}
+  in
+  let cfg_on =
+    Option.value_exn
+      (Repo_config.find_by_github ~owner:"rocq-prover" ~repo:"rocq" with_project)
+  in
+  let cfg_off =
+    Option.value_exn
+      (Repo_config.find_by_github ~owner:"my-org" ~repo:"my-repo"
+         without_project )
+  in
+  (check bool) "enabled" true (Repo_config.backport_enabled cfg_on) ;
+  (check bool) "disabled" false (Repo_config.backport_enabled cfg_off) ;
+  (check string) "org" "rocq-prover" (Repo_config.project_organization cfg_on) ;
+  (check string) "org fallback" "my-org"
+    (Repo_config.project_organization cfg_off) ;
+  (check bool) "card match" true
+    (Option.is_some
+       (Repo_config.find_by_backport_project ~install_id:102161
+          ~project_number:11 with_project ) ) ;
+  (check bool) "card miss" true
+    (Option.is_none
+       (Repo_config.find_by_backport_project ~install_id:102161
+          ~project_number:11 without_project ) )
+
 let () =
   run "Repo_config tests"
     [ ( "parse"
@@ -88,4 +130,5 @@ let () =
         ; ("minimal config", `Quick, test_minimal_config)
         ; ("bad github", `Quick, test_bad_github)
         ; ("missing section", `Quick, test_missing_section)
-        ; ("find miss", `Quick, test_find_miss) ] ) ]
+        ; ("find miss", `Quick, test_find_miss)
+        ; ("backport enabled", `Quick, test_backport_enabled) ] ) ]


### PR DESCRIPTION
- Rename `rocq_push_action` to `push_action` and drive owner/repo/project/org from `repo_config`
- Parameterize `add_to_column` with organization and project number
- Skip backport on push when `github_project_number` is absent; match `PullRequestCardEdited` via install id + project number from config
- Add tests for backport helpers with and without `github_project_number`

Remaining Rocq hardcodes for follow-up PRs.
