### PR TITLE
Drive CI job dispatch and doc status from repo_config

### DIFF
--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -68,6 +68,7 @@ app_id="31373"
  # Use Rocq-specific failure summaries / allow-failure handling
  use_rocq_job_status = true
  # Successful jobs that get a GitHub status check linking to doc artifacts
+ silence_docker_manifest_errors = true
  doc_artifact_jobs = [
   "doc:refman", "doc:ci-refman", "doc:init",
   "doc:stdlib", "doc:stdlib:dune", "doc:ml-api:odoc"

--- a/src/actions/job.ml
+++ b/src/actions/job.ml
@@ -63,10 +63,17 @@ let job_action ~bot_info
                       ~gitlab_repo_full_name:_
                     -> Lwt.return_unit )
             in
+            let silence_docker_manifest_errors =
+              match repo_config with
+              | Some cfg ->
+                  cfg.jobs.silence_docker_manifest_errors
+              | None ->
+                  false
+            in
             Job_status.job_failure ~bot_info job_info ~pr_num
               (gh_owner, gh_repo) ~gitlab_domain ~gitlab_repo_full_name ~context
-              ~failure_reason ~external_id ~summary_builder
-              ~allow_failure_handler ()
+              ~failure_reason ~external_id ~silence_docker_manifest_errors
+              ~summary_builder ~allow_failure_handler ()
         | "success" as state ->
             Job_status.job_success_or_pending ~bot_info (gh_owner, gh_repo)
               job_info ~gitlab_domain ~gitlab_repo_full_name ~context ~state

--- a/src/actions/job.ml
+++ b/src/actions/job.ml
@@ -19,7 +19,6 @@ let job_action ~bot_info
         github_repo_of_gitlab_project_path ~gitlab_mapping ~gitlab_domain
           ~gitlab_repo_full_name
       in
-      let github_repo_full_name = gh_owner ^ "/" ^ gh_repo in
       let repo_config =
         Repo_config.find_by_github ~owner:gh_owner ~repo:gh_repo
           repo_config_table
@@ -74,12 +73,36 @@ let job_action ~bot_info
               (gh_owner, gh_repo) ~gitlab_domain ~gitlab_repo_full_name ~context
               ~failure_reason ~external_id ~silence_docker_manifest_errors
               ~summary_builder ~allow_failure_handler ()
-        | "success" as state ->
+        | "success" as state -> (
             Job_status.job_success_or_pending ~bot_info (gh_owner, gh_repo)
               job_info ~gitlab_domain ~gitlab_repo_full_name ~context ~state
               ~external_id
-            <&> Documentation.send_doc_url ~bot_info job_info
-                  ~github_repo_full_name
+            <&>
+            match repo_config with
+            | Some cfg when Repo_config.is_doc_artifact_job cfg build_name -> (
+              match
+                Repo_config.gitlab_job_url cfg ~job_id:job_info.build_id
+              with
+              | None ->
+                  Lwt_io.printl
+                    "Doc artifact job configured but GitLab coordinates \
+                     missing; skipping doc status."
+              | Some gitlab_job_url ->
+                  let artifact_url artifact =
+                    match
+                      Repo_config.gitlab_pages_artifact_url cfg
+                        ~job_id:job_info.build_id ~artifact
+                    with
+                    | Some url ->
+                        url
+                    | None ->
+                        gitlab_job_url
+                  in
+                  Documentation.send_doc_url ~bot_info
+                    ~github_repo_full_name:(Repo_config.github_full_name cfg)
+                    ~gitlab_job_url ~artifact_url job_info )
+            | _ ->
+                Lwt.return_unit )
         | ("created" | "running") as state ->
             Job_status.job_success_or_pending ~bot_info (gh_owner, gh_repo)
               job_info ~gitlab_domain ~gitlab_repo_full_name ~context ~state

--- a/src/actions/job.ml
+++ b/src/actions/job.ml
@@ -7,7 +7,8 @@ open Utils
 open Lwt.Infix
 
 let job_action ~bot_info
-    ({build_name; common_info= {http_repo_url}} as job_info) ~gitlab_mapping =
+    ({build_name; common_info= {http_repo_url}} as job_info) ~gitlab_mapping
+    ~repo_config_table =
   let pr_num, branch_or_pr = pr_from_branch job_info.common_info.branch in
   let context = f "GitLab CI job %s (%s)" build_name branch_or_pr in
   match parse_gitlab_repo_url ~http_repo_url with
@@ -19,43 +20,48 @@ let job_action ~bot_info
           ~gitlab_repo_full_name
       in
       let github_repo_full_name = gh_owner ^ "/" ^ gh_repo in
+      let repo_config =
+        Repo_config.find_by_github ~owner:gh_owner ~repo:gh_repo
+          repo_config_table
+      in
       let external_id =
         f "%s,projects/%d/jobs/%d" http_repo_url job_info.common_info.project_id
           job_info.build_id
       in
-      match (github_repo_full_name, job_info.build_name) with
-      | "rocq-prover/rocq", "bench" ->
+      match repo_config with
+      | Some cfg when Repo_config.is_bench_job cfg build_name ->
           Bench.update_bench_status ~bot_info ~job_info (gh_owner, gh_repo)
             ~external_id ~number:pr_num
-      | _, _ -> (
+      | _ -> (
         match job_info.build_status with
         | "failed" ->
             let failure_reason = Option.value_exn job_info.failure_reason in
             let summary_builder, allow_failure_handler =
-              if String.equal github_repo_full_name "rocq-prover/rocq" then
-                ( Job_status_rocq.rocq_summary_builder
-                , fun ~bot_info
-                    ~job_name
-                    ~job_url
-                    ~pr_num
-                    ~head_commit
-                    (gh_owner, gh_repo)
-                    ~gitlab_repo_full_name
-                  ->
-                    Job_status_rocq.handle_rocq_allow_failure ~bot_info
-                      ~job_name ~job_url ~pr_num ~head_commit
-                      (gh_owner, gh_repo) ~gitlab_repo_full_name )
-              else
-                ( (fun _trace_lines trace_description ->
-                    Lwt.return trace_description )
-                , fun ~bot_info:_
-                    ~job_name:_
-                    ~job_url:_
-                    ~pr_num:_
-                    ~head_commit:_
-                    _
-                    ~gitlab_repo_full_name:_
-                  -> Lwt.return_unit )
+              match repo_config with
+              | Some cfg when cfg.jobs.use_rocq_job_status ->
+                  ( Job_status_rocq.rocq_summary_builder
+                  , fun ~bot_info
+                      ~job_name
+                      ~job_url
+                      ~pr_num
+                      ~head_commit
+                      (gh_owner, gh_repo)
+                      ~gitlab_repo_full_name
+                    ->
+                      Job_status_rocq.handle_rocq_allow_failure ~bot_info
+                        ~job_name ~job_url ~pr_num ~head_commit
+                        (gh_owner, gh_repo) ~gitlab_repo_full_name )
+              | _ ->
+                  ( (fun _trace_lines trace_description ->
+                      Lwt.return trace_description )
+                  , fun ~bot_info:_
+                      ~job_name:_
+                      ~job_url:_
+                      ~pr_num:_
+                      ~head_commit:_
+                      _
+                      ~gitlab_repo_full_name:_
+                    -> Lwt.return_unit )
             in
             Job_status.job_failure ~bot_info job_info ~pr_num
               (gh_owner, gh_repo) ~gitlab_domain ~gitlab_repo_full_name ~context

--- a/src/actions/job.mli
+++ b/src/actions/job.mli
@@ -4,4 +4,5 @@ val job_action :
      bot_info:Bot_info.t
   -> GitLab_types.ci_common_info GitLab_types.job_info
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
+  -> repo_config_table:(string, Repo_config.t) Base.Hashtbl.t
   -> unit Lwt.t

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -49,7 +49,8 @@ let callback _conn req body =
   match path with
   | "/job" | "/pipeline" (* legacy endpoints *) | "/gitlab" ->
       Gitlab.handle_gitlab_webhook ~bot_info ~key ~app_id ~gitlab_mapping
-        ~gitlab_webhook_secret ~headers:(Request.headers req) ~body
+        ~repo_config_table ~gitlab_webhook_secret ~headers:(Request.headers req)
+        ~body
   | "/push" | "/pull_request" (* legacy endpoints *) | "/github" ->
       Github.handle_github_webhook ~bot_info ~key ~app_id ~github_bot_name
         ~gitlab_mapping ~repo_config_table ~github_mapping

--- a/src/ci/documentation.ml
+++ b/src/ci/documentation.ml
@@ -6,7 +6,8 @@ open Cohttp
 open Cohttp_lwt_unix
 open Lwt.Infix
 
-let rec send_doc_url_aux ~bot_info job_info ~fallback_urls (kind, url) =
+let rec send_doc_url_aux ~bot_info ~github_repo_full_name ~gitlab_job_url
+    job_info ~fallback_urls (kind, url) =
   let context = f "%s: %s artifact" job_info.build_name kind in
   let description_base = f "Link to %s build artifact" kind in
   let open Lwt.Syntax in
@@ -15,21 +16,17 @@ let rec send_doc_url_aux ~bot_info job_info ~fallback_urls (kind, url) =
     resp |> Response.status |> Code.code_of_status
   in
   let success_response url =
-    GitHub_mutations.send_status_check ~repo_full_name:"rocq-prover/rocq"
+    GitHub_mutations.send_status_check ~repo_full_name:github_repo_full_name
       ~commit:job_info.common_info.head_commit ~state:"success" ~url ~context
       ~description:(description_base ^ ".") ~bot_info
   in
   let fail_response code =
     Lwt_io.printf "But we got a %d code when checking the URL.\n" code
-    <&>
-    let job_url =
-      f "https://gitlab.inria.fr/coq/coq/-/jobs/%d" job_info.build_id
-    in
-    GitHub_mutations.send_status_check ~repo_full_name:"rocq-prover/rocq"
-      ~commit:job_info.common_info.head_commit ~state:"failure" ~url:job_url
-      ~context
-      ~description:(description_base ^ ": not found.")
-      ~bot_info
+    <&> GitHub_mutations.send_status_check ~repo_full_name:github_repo_full_name
+          ~commit:job_info.common_info.head_commit ~state:"failure"
+          ~url:gitlab_job_url ~context
+          ~description:(description_base ^ ": not found.")
+          ~bot_info
   in
   let error_code url =
     let+ status_code = status_code url in
@@ -44,42 +41,40 @@ let rec send_doc_url_aux ~bot_info job_info ~fallback_urls (kind, url) =
     | [] ->
         fail_response code
     | url :: fallback_urls ->
-        send_doc_url_aux ~bot_info ~fallback_urls job_info (kind, url) )
+        send_doc_url_aux ~bot_info ~github_repo_full_name ~gitlab_job_url
+          job_info ~fallback_urls (kind, url) )
 
-let send_doc_url_job ~bot_info ?(fallback_artifacts = []) job_info doc_key
-    artifact =
+let send_doc_url_job ~bot_info ~github_repo_full_name ~gitlab_job_url
+    ~artifact_url ?(fallback_artifacts = []) job_info doc_key artifact =
   Lwt_io.printf
     "This is a successful %s build. Pushing a status check with a link...\n"
     doc_key
-  <&>
-  let build_url artifact =
-    f "https://coq.gitlabpages.inria.fr/-/coq/-/jobs/%d/artifacts/%s"
-      job_info.build_id artifact
-  in
-  send_doc_url_aux ~bot_info job_info
-    ~fallback_urls:(List.map ~f:build_url fallback_artifacts)
-    (doc_key, build_url artifact)
+  <&> send_doc_url_aux ~bot_info ~github_repo_full_name ~gitlab_job_url job_info
+        ~fallback_urls:(List.map ~f:artifact_url fallback_artifacts)
+        (doc_key, artifact_url artifact)
 
-let send_doc_url ~bot_info ~github_repo_full_name job_info =
-  match (github_repo_full_name, job_info.build_name) with
-  | "rocq-prover/rocq", "doc:refman" ->
-      send_doc_url_job ~bot_info job_info "refman"
+let send_doc_url ~bot_info ~github_repo_full_name ~gitlab_job_url ~artifact_url
+    job_info =
+  let send ?(fallback_artifacts = []) doc_key artifact =
+    send_doc_url_job ~bot_info ~github_repo_full_name ~gitlab_job_url
+      ~artifact_url ~fallback_artifacts job_info doc_key artifact
+  in
+  match job_info.build_name with
+  | "doc:refman" ->
+      send
         ~fallback_artifacts:["_build/default/doc/refman-html/index.html"]
-        "doc/refman-html/index.html"
-  | "rocq-prover/rocq", "doc:ci-refman" ->
-      send_doc_url_job ~bot_info job_info "ci-refman"
+        "refman" "doc/refman-html/index.html"
+  | "doc:ci-refman" ->
+      send
         ~fallback_artifacts:["_build/default/doc/refman-html/index.html"]
-        "_build_ci/refman/refman-html/index.html"
-  | "rocq-prover/rocq", "doc:init" ->
-      send_doc_url_job ~bot_info job_info "corelib"
-        "_build/default/doc/corelib/html/index.html"
-  | ( "rocq-prover/rocq"
-    , ( "doc:stdlib" (* only after complete switch to Dune *)
-      | "doc:stdlib:dune" (* only before complete switch to Dune *) ) ) ->
-      send_doc_url_job ~bot_info job_info "stdlib"
-        "_build/default/doc/stdlib/html/index.html"
-  | "rocq-prover/rocq", "doc:ml-api:odoc" ->
-      send_doc_url_job ~bot_info job_info "ml-api"
-        "_build/default/_doc/_html/index.html"
+        "ci-refman" "_build_ci/refman/refman-html/index.html"
+  | "doc:init" ->
+      send "corelib" "_build/default/doc/corelib/html/index.html"
+  | "doc:stdlib" ->
+      send "stdlib" "_build/default/doc/stdlib/html/index.html"
+  | "doc:stdlib:dune" ->
+      send "stdlib" "_build/default/doc/stdlib/html/index.html"
+  | "doc:ml-api:odoc" ->
+      send "ml-api" "_build/default/_doc/_html/index.html"
   | _ ->
       Lwt.return_unit

--- a/src/ci/documentation.mli
+++ b/src/ci/documentation.mli
@@ -1,6 +1,8 @@
 val send_doc_url :
      bot_info:Bot_components.Bot_info.t
   -> github_repo_full_name:string
+  -> gitlab_job_url:string
+  -> artifact_url:(string -> string)
   -> Bot_components.GitLab_types.ci_common_info
      Bot_components.GitLab_types.job_info
   -> unit Lwt.t

--- a/src/ci/job_status.ml
+++ b/src/ci/job_status.ml
@@ -121,7 +121,7 @@ let send_status_check ~bot_info job_info ~pr_num (gh_owner, gh_repo)
 (* GitLab Trace Processing Utilities                                          *)
 (******************************************************************************)
 
-let trace_action ~repo_full_name trace =
+let trace_action ~silence_docker_manifest_errors trace =
   trace |> String.length
   |> Lwt_io.printlf "Trace size: %d."
   >>= fun () ->
@@ -158,14 +158,14 @@ let trace_action ~repo_full_name trace =
        || test "fatal: [Cc]ouldn't find remote ref refs/heads/pr-"
      then Ignore "Normal failure: pull request was closed."
      else if
-       String.equal repo_full_name "coq/coq"
+       silence_docker_manifest_errors
        && test "Error response from daemon: manifest for .* not found"
      then Ignore "Docker image not found. Do not report anything specific."
      else Warn trace )
 
 let job_failure ~bot_info job_info ~pr_num (gh_owner, gh_repo) ~gitlab_domain
     ~gitlab_repo_full_name ~context ~failure_reason ~external_id
-    ?summary_builder ?allow_failure_handler () =
+    ~silence_docker_manifest_errors ?summary_builder ?allow_failure_handler () =
   let build_id = job_info.build_id in
   let project_id =
     (job_info.common_info : Bot_components.GitLab_types.ci_common_info)
@@ -185,7 +185,7 @@ let job_failure ~bot_info job_info ~pr_num (gh_owner, gh_repo) ~gitlab_domain
         ~build_id
       >>= function
       | Ok trace ->
-          trace_action ~repo_full_name:gitlab_repo_full_name trace
+          trace_action ~silence_docker_manifest_errors trace
       | Error err ->
           Lwt.return (Ignore (f "Error while retrieving the trace: %s." err)) )
   >>= function

--- a/src/ci/job_status.mli
+++ b/src/ci/job_status.mli
@@ -25,7 +25,8 @@ val send_status_check :
   -> unit
   -> unit Lwt.t
 
-val trace_action : repo_full_name:string -> string -> build_failure Lwt.t
+val trace_action :
+  silence_docker_manifest_errors:bool -> string -> build_failure Lwt.t
 
 val job_failure :
      bot_info:Bot_components.Bot_info.t
@@ -38,6 +39,7 @@ val job_failure :
   -> context:string
   -> failure_reason:string
   -> external_id:string
+  -> silence_docker_manifest_errors:bool
   -> ?summary_builder:(string list -> string -> string Lwt.t)
   -> ?allow_failure_handler:
        (   bot_info:Bot_components.Bot_info.t

--- a/src/config/repo_config.ml
+++ b/src/config/repo_config.ml
@@ -167,4 +167,3 @@ let gitlab_pages_artifact_url cfg ~job_id ~artifact =
            repo job_id artifact )
   | _ ->
       None
-

--- a/src/config/repo_config.ml
+++ b/src/config/repo_config.ml
@@ -132,3 +132,39 @@ let find_by_backport_project ~install_id ~project_number tbl =
           Some cfg
       | _ ->
           None )
+
+let is_bench_job cfg build_name =
+  match cfg.jobs.bench_job with
+  | Some name ->
+      String.equal name build_name
+  | None ->
+      false
+
+let is_doc_artifact_job cfg build_name =
+  List.mem cfg.jobs.doc_artifact_jobs build_name ~equal:String.equal
+
+let github_full_name cfg = cfg.github_owner ^ "/" ^ cfg.github_repo
+
+let gitlab_job_url cfg ~job_id =
+  match (cfg.gitlab_domain, cfg.gitlab_owner, cfg.gitlab_repo) with
+  | Some domain, Some owner, Some repo ->
+      Some (f "https://%s/%s/%s/-/jobs/%d" domain owner repo job_id)
+  | _ ->
+      None
+
+let gitlab_pages_host domain owner =
+  if String.equal domain "gitlab.com" then owner ^ ".gitlab.io"
+  else if String.is_prefix domain ~prefix:"gitlab." then
+    owner ^ ".gitlabpages." ^ String.drop_prefix domain 7
+  else owner ^ ".gitlablpages." ^ domain
+
+let gitlab_pages_artifact_url cfg ~job_id ~artifact =
+  match (cfg.gitlab_domain, cfg.gitlab_owner, cfg.gitlab_repo) with
+  | Some domain, Some owner, Some repo ->
+      Some
+        (f "https://%s/-/%s/-/jobs/%d/artifacts/%s"
+           (gitlab_pages_host domain owner)
+           repo job_id artifact )
+  | _ ->
+      None
+

--- a/src/config/repo_config.ml
+++ b/src/config/repo_config.ml
@@ -4,6 +4,7 @@ open Utils
 type repo_jobs_config =
   { bench_job: string option
   ; use_rocq_job_status: bool
+  ; silence_docker_manifest_errors: bool
   ; doc_artifact_jobs: string list }
 
 type backport_config = {github_project_number: int option}
@@ -25,7 +26,10 @@ type t =
   ; jobs: repo_jobs_config }
 
 let default_jobs =
-  {bench_job= None; use_rocq_job_status= false; doc_artifact_jobs= []}
+  { bench_job= None
+  ; use_rocq_job_status= false
+  ; silence_docker_manifest_errors= false
+  ; doc_artifact_jobs= [] }
 
 let default_backporting = {github_project_number= None}
 
@@ -40,6 +44,9 @@ let parse_jobs tbl key =
               if String.is_empty s then None else Some s )
       ; use_rocq_job_status=
           key_bool jobs_tbl "use_rocq_job_status" |> Option.value ~default:false
+      ; silence_docker_manifest_errors=
+          key_bool jobs_tbl "silence_docker_manifest_errors"
+          |> Option.value ~default:false
       ; doc_artifact_jobs=
           key_array jobs_tbl "doc_artifact_jobs" |> Option.value ~default:[] }
 

--- a/src/config/repo_config.mli
+++ b/src/config/repo_config.mli
@@ -44,4 +44,3 @@ val gitlab_job_url : t -> job_id:int -> string option
 
 val gitlab_pages_artifact_url :
   t -> job_id:int -> artifact:string -> string option
-

--- a/src/config/repo_config.mli
+++ b/src/config/repo_config.mli
@@ -33,3 +33,15 @@ val backport_enabled : t -> bool
 
 val find_by_backport_project :
   install_id:int -> project_number:int -> (string, t) Base.Hashtbl.t -> t option
+
+val is_bench_job : t -> string -> bool
+
+val is_doc_artifact_job : t -> string -> bool
+
+val github_full_name : t -> string
+
+val gitlab_job_url : t -> job_id:int -> string option
+
+val gitlab_pages_artifact_url :
+  t -> job_id:int -> artifact:string -> string option
+

--- a/src/config/repo_config.mli
+++ b/src/config/repo_config.mli
@@ -1,6 +1,7 @@
 type repo_jobs_config =
   { bench_job: string option
   ; use_rocq_job_status: bool
+  ; silence_docker_manifest_errors: bool
   ; doc_artifact_jobs: string list }
 
 type backport_config = {github_project_number: int option}

--- a/src/webhooks/gitlab.ml
+++ b/src/webhooks/gitlab.ml
@@ -8,7 +8,7 @@ open Lwt.Infix
 open Utils
 
 let handle_gitlab_webhook ~bot_info ~key ~app_id ~gitlab_mapping
-    ~gitlab_webhook_secret ~headers ~body =
+    ~repo_config_table ~gitlab_webhook_secret ~headers ~body =
   body
   >>= fun body ->
   match
@@ -24,7 +24,7 @@ let handle_gitlab_webhook ~bot_info ~key ~app_id ~gitlab_mapping
         (fun () ->
           Bot_components.Github_installations.action_as_github_app ~bot_info
             ~key ~app_id ~owner
-            (Job.job_action ~gitlab_mapping job_info) )
+            (Job.job_action ~gitlab_mapping ~repo_config_table job_info) )
         |> Lwt.async ;
         Server.respond_string ~status:`OK ~body:"Job event." () )
   | Ok (_, PipelineEvent ({common_info= {http_repo_url}} as pipeline_info)) -> (

--- a/src/webhooks/gitlab.mli
+++ b/src/webhooks/gitlab.mli
@@ -5,6 +5,7 @@ val handle_gitlab_webhook :
   -> key:Mirage_crypto_pk.Rsa.priv
   -> app_id:int
   -> gitlab_mapping:(string, string) Base.Hashtbl.t
+  -> repo_config_table:(string, Repo_config.t) Base.Hashtbl.t
   -> gitlab_webhook_secret:string
   -> headers:Cohttp.Header.t
   -> body:string Lwt.t

--- a/tests/test_repo_config.ml
+++ b/tests/test_repo_config.ml
@@ -126,6 +126,62 @@ let test_backport_enabled () =
        (Repo_config.find_by_backport_project ~install_id:102161
           ~project_number:11 without_project ) )
 
+let test_jobs_helper () =
+  let with_jobs =
+    parse
+      {|
+    [repositories.rocq]
+    github = "rocq-prover/rocq"
+    gitlab_domain = "gitlab.inria.fr"
+    gitlab_owner = "coq"
+    gitlab_repo = "coq"
+
+    [repositories.rocq.jobs]
+    bench_job = "bench"
+    use_rocq_job_status = true
+    silence_docker_manifest_errors = true
+    doc_artifact_jobs = ["doc:refman", "doc:stdlib"]
+    |}
+  in
+  let without_jobs =
+    parse {|
+  [repositories.demo]
+  github = "my-org/my-repo"
+  |}
+  in
+  let cfg_on =
+    Option.value_exn
+      (Repo_config.find_by_github ~owner:"rocq-prover" ~repo:"rocq" with_jobs)
+  in
+  let cfg_off =
+    Option.value_exn
+      (Repo_config.find_by_github ~owner:"my-org" ~repo:"my-repo" without_jobs)
+  in
+  (check bool) "bench on" true (Repo_config.is_bench_job cfg_on "bench") ;
+  (check bool) "bench wrong name" false
+    (Repo_config.is_bench_job cfg_on "build") ;
+  (check bool) "bench absent" false
+    (Repo_config.is_bench_job cfg_off "bench_job") ;
+  (check bool) "doc on" true
+    (Repo_config.is_doc_artifact_job cfg_on "doc:refman") ;
+  (check bool) "doc off" false
+    (Repo_config.is_doc_artifact_job cfg_off "doc:refman") ;
+  (check string) "gh name" "rocq-prover/rocq"
+    (Repo_config.github_full_name cfg_on) ;
+  (check (option string))
+    "job url" (Some "https://gitlab.inria.fr/coq/coq/-/jobs/42")
+    (Repo_config.gitlab_job_url cfg_on ~job_id:42) ;
+  (check (option string))
+    "pages url"
+    (Some
+       "https://coq.gitlabpages.inria.fr/-/coq/-/jobs/42/artifacts/doc/index.html"
+    )
+    (Repo_config.gitlab_pages_artifact_url cfg_on ~job_id:42
+       ~artifact:"doc/index.html" ) ;
+  (check (option string))
+    "job url missing" None
+    (Repo_config.gitlab_job_url cfg_off ~job_id:1)
+
 let () =
   run "Repo_config tests"
     [ ( "parse"
@@ -134,4 +190,5 @@ let () =
         ; ("bad github", `Quick, test_bad_github)
         ; ("missing section", `Quick, test_missing_section)
         ; ("find miss", `Quick, test_find_miss)
-        ; ("backport enabled", `Quick, test_backport_enabled) ] ) ]
+        ; ("backport enabled", `Quick, test_backport_enabled)
+        ; ("jobs", `Quick, test_jobs_helper) ] ) ]

--- a/tests/test_repo_config.ml
+++ b/tests/test_repo_config.ml
@@ -30,6 +30,7 @@ let test_full_config () =
     [repositories.rocq.jobs]
     bench_job = "bench"
     use_rocq_job_status = true
+    silence_docker_manifest_errors = true
     doc_artifact_jobs = ["doc:refman", "doc:stdlib"]
     |}
   in
@@ -45,6 +46,8 @@ let test_full_config () =
       (check int) "teams" 2 (List.length cfg.teams) ;
       (check (option string)) "bench_job" (Some "bench") cfg.jobs.bench_job ;
       (check bool) "use_rocq_job_status" true cfg.jobs.use_rocq_job_status ;
+      (check bool) "silence_docker_manifest_errors" true
+        cfg.jobs.silence_docker_manifest_errors ;
       (check int) "doc_artifact_jobs" 2 (List.length cfg.jobs.doc_artifact_jobs)
 
 let test_minimal_config () =

--- a/tests/test_repo_config.ml
+++ b/tests/test_repo_config.ml
@@ -139,7 +139,7 @@ let test_jobs_helper () =
     [repositories.rocq.jobs]
     bench_job = "bench"
     use_rocq_job_status = true
-    silence_docker_manifest_errors = true
+    silence_docker_manifest_errors = true 
     doc_artifact_jobs = ["doc:refman", "doc:stdlib"]
     |}
   in


### PR DESCRIPTION
- Route bench jobs and Rocq-specific failure handling from `repo_config.jobs` (`bench_job`, `use_rocq_job_status`)
- Replace hardcoded `coq/coq` Docker-manifest silencing with `silence_docker_manifest_errors`
- Build doc artifact / GitLab status URLs from repo GitLab coordinates; gate on `doc_artifact_jobs`
- Thread `repo_config_table` through the GitLab job webhook into `job_action`
- Add helpers + Alcotest coverage for the new job config fields
